### PR TITLE
Fix#7 duplicate start method

### DIFF
--- a/flask/audio_grabber.py
+++ b/flask/audio_grabber.py
@@ -88,7 +88,7 @@ class AudioGrabber:
             session.mount('http://', adapter)
             session.mount('https://', adapter)
             headers = {'Content-Type': 'application/json'}  # Ensure correct header
-            response = session.post('http://localhost:5000/transcribe', json=data)
+            response = session.post('http://localhost:5040/transcribe', json=data)
         
             if response.status_code == 200:
                 print(f'Sent chunk {self.chunk_id} with {len(self.buffer)} bytes')

--- a/flask/audio_grabber.py
+++ b/flask/audio_grabber.py
@@ -70,10 +70,6 @@ class AudioGrabber:
         # Return the status code to continue the stream
         return audio_data, pyaudio.paContinue
     
-    def start(self):
-        self.send_thread = threading.Thread(target=self.send_audio)
-        self.send_thread.start()
-
     def is_silent(self, data):
         m = max(data)
         print(str(m))
@@ -92,7 +88,7 @@ class AudioGrabber:
             session.mount('http://', adapter)
             session.mount('https://', adapter)
             headers = {'Content-Type': 'application/json'}  # Ensure correct header
-            response = session.post('http://localhost:5040/transcribe', json=data)
+            response = session.post('http://localhost:5000/transcribe', json=data)
         
             if response.status_code == 200:
                 print(f'Sent chunk {self.chunk_id} with {len(self.buffer)} bytes')
@@ -105,6 +101,8 @@ class AudioGrabber:
 
     def start(self):
         self.stream.start_stream()
+        self.send_thread = threading.Thread(target=self.send_chunk)
+        self.send_thread.start()
 
     def stop(self):
         self.recording = False


### PR DESCRIPTION
Fixes #7

Problem:
The Audio Grabber class had two start() methods. In Python, the second one silently overrides the first, causing the threading logic to never execute.

Fix:
Merged both start() methods into one that:
- Starts the audio stream
- Starts the background send thread
- Fixed reference to non-existent send_audio method, changed to send_chunk

Tested:
Verified audio capture and chunk sending work correctly after the fix.

Hi, I'm Tanya, a GSoC aspirant interested in contributing to Susi_translator long-term.

I've set up the project locally, understood the codebase, and this is my first PR. I have an Android development background and had some ideas for the project's future:

1. Build a lightweight Android/Flutter app as a mobile client that connects to the whisper server for live transcription
2. Reduce transcription latency for truly real-time performance
3. Add GPU auto-detection for faster processing

Would love to know the mentor's thoughts on these directions 
and if any would be suitable as a GSoC project!