### PR TITLE
feat: add Celery+Redis task queue for horizontal Whisper transcriptio…

### DIFF
--- a/django/transcribe_app/apps.py
+++ b/django/transcribe_app/apps.py
@@ -2,12 +2,17 @@
 # (C) Michael Peter Christen 2024
 # Licensed under Apache License Version 2.0
 
+import os
 from django.apps import AppConfig
-import threading
-from .transcribe_utils import process_audio
+
 
 class TranscribeAppConfig(AppConfig):
     name = 'transcribe_app'
 
     def ready(self):
-        threading.Thread(target=process_audio, daemon=True).start()
+        use_celery = os.getenv('USE_CELERY', 'false').lower() == 'true'
+        if not use_celery:
+            # Legacy mode: start the background processing thread
+            import threading
+            from .transcribe_utils import process_audio
+            threading.Thread(target=process_audio, daemon=True).start()

--- a/django/transcribe_app/tasks.py
+++ b/django/transcribe_app/tasks.py
@@ -1,0 +1,249 @@
+# transcribe_app/tasks.py
+# (C) Michael Peter Christen 2024
+# Licensed under Apache License Version 2.0
+
+"""
+Celery task definitions for audio transcription and translation.
+
+These tasks replace the ``while True`` background thread in the original
+``transcribe_utils.process_audio()`` with discrete, independently
+schedulable units of work.  Each task is idempotent and safe to retry.
+"""
+
+import io
+import os
+import logging
+
+import base64
+import numpy as np
+import requests
+import json
+import time
+
+from celery import shared_task
+from scipy.io.wavfile import write as wav_write
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Environment / model configuration  (mirrors transcribe_utils.py)
+# ---------------------------------------------------------------------------
+
+use_whisper_server = os.getenv('WHISPER_SERVER_USE', 'true') == 'true'
+whisper_server = os.getenv('WHISPER_SERVER', 'https://whisper.susi.ai')
+
+model_fast_name = os.getenv('WHISPER_MODEL', 'small')
+model_smart_name = os.getenv('WHISPER_MODEL', 'medium')
+
+# Lazy-loaded whisper models (only when USE_CELERY=true AND local whisper)
+_model_fast = None
+_model_smart = None
+
+
+def _get_model_fast():
+    """Lazy-load the fast whisper model on first use inside a worker."""
+    global _model_fast
+    if _model_fast is None:
+        import whisper, torch
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        models_path = os.path.join(script_dir, 'models')
+        if os.path.exists(os.path.join(models_path, model_fast_name + ".pt")):
+            _model_fast = whisper.load_model(model_fast_name, in_memory=True, download_root=models_path)
+        else:
+            _model_fast = whisper.load_model(model_fast_name, in_memory=True)
+    return _model_fast
+
+
+# ---------------------------------------------------------------------------
+# Utility imports (kept in transcribe_utils to avoid duplication)
+# ---------------------------------------------------------------------------
+
+def _is_valid(transcript):
+    """Re-use the validation logic from transcribe_utils."""
+    from .transcribe_utils import is_valid
+    return is_valid(transcript)
+
+
+def _translate(text, source_language, target_language):
+    """Re-use the translation logic from transcribe_utils."""
+    from .transcribe_utils import translate
+    return translate(text, source_language, target_language)
+
+
+# ---------------------------------------------------------------------------
+# Core Celery tasks
+# ---------------------------------------------------------------------------
+
+@shared_task(
+    bind=True,
+    name='transcribe_app.tasks.process_audio_chunk',
+    acks_late=True,
+    max_retries=3,
+    default_retry_delay=5,
+)
+def process_audio_chunk(self, tenant_id, chunk_id, audio_b64, translate_from, translate_to):
+    """
+    Transcribe a single audio chunk using Whisper and store the result.
+
+    This is the Celery equivalent of the inner loop body from the original
+    ``transcribe_utils.process_audio()`` function.
+
+    Parameters
+    ----------
+    tenant_id : str
+        Tenant identifier for multi-tenant isolation.
+    chunk_id : str
+        Unique identifier for this audio chunk (typically a millisecond timestamp).
+    audio_b64 : str
+        Base64-encoded raw PCM audio (int16, 16 kHz mono).
+    translate_from : str or None
+        Source language code for optional translation.
+    translate_to : str or None
+        Target language code for optional translation.
+    """
+    from .transcript_store import store
+
+    try:
+        # Decode base64 audio
+        audio_data = base64.b64decode(audio_b64)
+        audio_array = np.frombuffer(audio_data, dtype=np.int16)
+
+        if audio_array.size == 0:
+            logger.warning("Invalid audio data for chunk_id %s", chunk_id)
+            return {'status': 'skipped', 'reason': 'empty_audio'}
+
+        if np.isnan(audio_array.astype(np.float32)).any():
+            logger.warning("NaN values in audio array for chunk_id %s", chunk_id)
+            return {'status': 'skipped', 'reason': 'nan_values'}
+
+        # ----- Transcribe -----
+        transcript = ''
+        if use_whisper_server:
+            # Whisper.cpp HTTP server
+            if audio_array.dtype != np.int16:
+                audio_array = audio_array.astype(np.int16)
+
+            wav_buffer = io.BytesIO()
+            wav_write(wav_buffer, 16000, audio_array)
+            wav_buffer.seek(0)
+
+            files = {'file': ('audio.wav', wav_buffer, 'audio/wav')}
+            data = {
+                'temperature': '0.0',
+                'temperature_inc': '0.0',
+                'response_format': 'json',
+            }
+            response = requests.post(f"{whisper_server}/inference", files=files, data=data)
+
+            if response.status_code == 200:
+                transcript = response.json().get('text', '').strip()
+            else:
+                logger.error("Whisper server error: %s %s", response.status_code, response.text)
+                raise self.retry(exc=Exception(f"Whisper server returned {response.status_code}"))
+        else:
+            # Local PyTorch whisper model
+            import torch
+            model = _get_model_fast()
+            audio_float = audio_array.astype(np.float32) / 32768.0
+            audio_tensor = torch.from_numpy(audio_float)
+            result = model.transcribe(audio_tensor, temperature=0)
+            transcript = result.get('text', '').strip()
+
+        # ----- Validate & store -----
+        if _is_valid(transcript):
+            logger.info("VALID transcript for chunk_id %s: %s", chunk_id, transcript)
+
+            # Check if this chunk_id already exists (overwrite case)
+            existing = store.get_transcript_event(tenant_id, chunk_id)
+            if not existing:
+                # New chunk — trigger translation on previous chunks
+                chunk_ids = store.get_chunk_ids(tenant_id)
+                if len(chunk_ids) >= 1:
+                    _try_translate_chunk(tenant_id, chunk_ids[-1])
+
+            transcript_event = {
+                'translated': False,
+                'transcript': transcript,
+                'translate_from': translate_from,
+                'translate_to': translate_to,
+            }
+            store.set_transcript(tenant_id, chunk_id, transcript_event)
+        else:
+            logger.warning("INVALID transcript for chunk_id %s: %s", chunk_id, transcript)
+
+        return {'status': 'ok', 'chunk_id': chunk_id, 'transcript': transcript}
+
+    except Exception as exc:
+        logger.error("Error processing audio chunk %s", chunk_id, exc_info=True)
+        raise self.retry(exc=exc)
+
+
+def _try_translate_chunk(tenant_id, chunk_id):
+    """
+    Check whether a transcript event needs translation and dispatch it.
+    """
+    from .transcript_store import store
+
+    event = store.get_transcript_event(tenant_id, chunk_id)
+    if not event:
+        return
+
+    translated = event.get('translated', False)
+    translate_to = event.get('translate_to', '')
+
+    if not translate_to or translate_to == '_' or translated:
+        return
+
+    # Dispatch the translation as a separate Celery task
+    translate_transcript.delay(tenant_id, chunk_id)
+
+
+@shared_task(
+    name='transcribe_app.tasks.translate_transcript',
+    acks_late=True,
+    max_retries=2,
+    default_retry_delay=3,
+)
+def translate_transcript(tenant_id, chunk_id):
+    """
+    Translate a single stored transcript event.
+    """
+    from .transcript_store import store
+
+    event = store.get_transcript_event(tenant_id, chunk_id)
+    if not event:
+        return {'status': 'skipped', 'reason': 'not_found'}
+
+    if event.get('translated', False):
+        return {'status': 'skipped', 'reason': 'already_translated'}
+
+    translate_from = event.get('translate_from', '')
+    translate_to = event.get('translate_to', '')
+    transcript = event.get('transcript', '')
+
+    if not translate_to or translate_to == '_':
+        return {'status': 'skipped', 'reason': 'no_target_language'}
+
+    # Mark translated early to prevent duplicate work
+    event['translated'] = True
+    store.set_transcript(tenant_id, chunk_id, event)
+
+    translation = _translate(transcript, translate_from, translate_to)
+    if translation:
+        event['transcript'] = translation
+        event['original'] = transcript
+        store.set_transcript(tenant_id, chunk_id, event)
+
+    return {'status': 'ok', 'chunk_id': chunk_id}
+
+
+@shared_task(name='transcribe_app.tasks.cleanup_old_transcripts_task')
+def cleanup_old_transcripts_task():
+    """
+    Periodic task: remove transcript events older than two hours.
+    Intended to be called via Celery Beat every 10 minutes.
+    """
+    from .transcript_store import store
+    store.cleanup_old()
+    logger.info("Cleaned up old transcripts")
+    return {'status': 'ok'}

--- a/django/transcribe_app/transcribe_utils.py
+++ b/django/transcribe_app/transcribe_utils.py
@@ -2,23 +2,45 @@
 # (C) Michael Peter Christen 2024
 # Licensed under Apache License Version 2.0
 
+"""
+Core transcription utilities.
+
+This module provides:
+  • Audio queue management (``add_to_audio_stack``, ``process_audio``)
+  • Transcript storage access (``get_transcripts``)
+  • Validation (``is_valid``)
+  • Translation helpers (``translate``, ``translate_with_llm``)
+  • Sentence merging (``merge_and_split_transcripts``)
+
+When ``USE_CELERY=true`` the ``add_to_audio_stack`` function dispatches a
+Celery task instead of pushing to the in-process ``queue.Queue()``, and the
+blocking ``process_audio()`` loop is *not* started.
+"""
+
 import os
 import io
 import numpy as np
 import threading
 import requests
 import logging
-import whisper
 import base64
 import queue
-import torch
 import json
 import time
 from scipy.io.wavfile import write as wav_write
 
 logger = logging.getLogger(__name__)
 
-# we either use a local in-code model or access a whisper.cpp server
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+use_celery = os.getenv('USE_CELERY', 'false').lower() == 'true'
+
+# ---------------------------------------------------------------------------
+# Whisper model configuration
+# ---------------------------------------------------------------------------
+
 use_whisper_server = os.getenv('WHISPER_SERVER_USE', 'true') == 'true'
 #model_name = os.getenv('WHISPER_MODEL', 'tiny')     # 39M
 #model_name = os.getenv('WHISPER_MODEL', 'base')     # 74M
@@ -26,66 +48,114 @@ model_fast_name = os.getenv('WHISPER_MODEL', 'small')    # 244M
 model_smart_name = os.getenv('WHISPER_MODEL', 'medium')   # 769M
 #model_name = os.getenv('WHISPER_MODEL', 'large-v3') # 1550M
 
-translation_cache = {}
+# ---------------------------------------------------------------------------
+# Translation state
+# ---------------------------------------------------------------------------
+
 translation_ongoing = False
 
-# In-memory storage for transcripts
-transcriptsd = {} # dictionary of objects; the key is the tenant_id and the value is a dictionary with the chunk_id as key and the transcript as value
-audio_stacks = {} # a dictionary of queues; the key is the tenant_id and the value is the queue, a queue.Queue() object
+# ---------------------------------------------------------------------------
+# Pluggable transcript store
+# ---------------------------------------------------------------------------
 
-if use_whisper_server:
-    # Use the whisper.cpp server
-    # this requires to start the server with the following command:
-    # cd whisper.cpp
-    # bash ./models/download-ggml-model.sh small
-    # bash ./models/download-ggml-model.sh medium
-    # bash ./models/download-ggml-model.sh large-v3
-    # ./server -m models/ggml-medium.bin -l de -p 16 -t 32 --host 0.0.0.0 --port 8007
-    # ./server -m models/ggml-large-v3.bin -l de -p 16 -t 32 --host 0.0.0.0 --port 8007
-    whisper_server = os.getenv('WHISPER_SERVER', 'https://whisper.susi.ai')
+from .transcript_store import store as _store
+
+# ---------------------------------------------------------------------------
+# Legacy in-memory state (used only when USE_CELERY=false)
+# ---------------------------------------------------------------------------
+
+if not use_celery:
+    # In-memory storage for transcripts
+    transcriptsd = {} # dictionary of objects; the key is the tenant_id and the value is a dictionary with the chunk_id as key and the transcript as value
+    audio_stacks = {} # a dictionary of queues; the key is the tenant_id and the value is the queue, a queue.Queue() object
+
+    if use_whisper_server:
+        # Use the whisper.cpp server
+        # this requires to start the server with the following command:
+        # cd whisper.cpp
+        # bash ./models/download-ggml-model.sh small
+        # bash ./models/download-ggml-model.sh medium
+        # bash ./models/download-ggml-model.sh large-v3
+        # ./server -m models/ggml-medium.bin -l de -p 16 -t 32 --host 0.0.0.0 --port 8007
+        # ./server -m models/ggml-large-v3.bin -l de -p 16 -t 32 --host 0.0.0.0 --port 8007
+        whisper_server = os.getenv('WHISPER_SERVER', 'https://whisper.susi.ai')
+    else:
+        # Download a whisper model. If the download using the whisper library is not possible
+        # i.e. if you are offline or behind a firewall, you can also use locally stored models.
+        # To use a local model, download a model from the links as listed in
+        # https://github.com/openai/whisper/blob/main/whisper/__init__.py#L17-L30
+        import whisper
+        import torch
+
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # load or download model
+        # the possible model path is models_path + "/" + model_name + ".pt"
+        # check if the model exists in the models_path
+        models_path = os.path.join(script_dir, 'models')
+        if os.path.exists(os.path.join(models_path, model_fast_name + ".pt")):
+            model_fast = whisper.load_model(model_fast_name, in_memory=True, download_root=models_path)
+        else:
+            model_fast = whisper.load_model(model_fast_name, in_memory=True)
+        if os.path.exists(os.path.join(models_path, model_smart_name + ".pt")):
+            model_smart = whisper.load_model(model_smart_name, in_memory=True, download_root=models_path)
+        else:
+            model_smart = whisper.load_model(model_smart_name, in_memory=True)
 else:
-    # Download a whisper model. If the download using the whisper library is not possible
-    # i.e. if you are offline or behind a firewall, you can also use locally stored models.
-    # To use a local model, download a model from the links as listed in
-    # https://github.com/openai/whisper/blob/main/whisper/__init__.py#L17-L30
+    whisper_server = os.getenv('WHISPER_SERVER', 'https://whisper.susi.ai')
+    logger.info("Celery mode enabled — audio processing delegated to Celery workers")
 
 
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-
-    # load or download model
-    # the possible model path is models_path + "/" + model_name + ".pt"
-    # check if the model exists in the models_path
-    models_path = os.path.join(script_dir, 'models')
-    if os.path.exists(os.path.join(models_path, model_fast_name + ".pt")):
-        model_fast = whisper.load_model(model_fast_name, in_memory=True, download_root=models_path)
-    else:
-        model_fast = whisper.load_model(model_fast_name, in_memory=True)
-    if os.path.exists(os.path.join(models_path, model_smart_name + ".pt")):
-        model_smart = whisper.load_model(model_smart_name, in_memory=True, download_root=models_path)
-    else:
-        model_smart = whisper.load_model(model_smart_name, in_memory=True)
+# ---------------------------------------------------------------------------
+# Public API — called by views.py
+# ---------------------------------------------------------------------------
 
 def add_to_audio_stack(tenant_id, chunk_id, audio_b64, translate_from, translate_to):
     """
-    Add an audio chunk to the queue for the given tenant.
+    Add an audio chunk to the processing pipeline.
+
+    In Celery mode this dispatches a ``process_audio_chunk`` task.
+    In legacy mode this pushes onto the in-process ``queue.Queue()``.
     """
-    with threading.Lock():
-        if tenant_id not in audio_stacks:
-            audio_stacks[tenant_id] = queue.Queue()
-        audio_stacks[tenant_id].put((chunk_id, audio_b64, translate_from, translate_to))
+    if use_celery:
+        from .tasks import process_audio_chunk
+        process_audio_chunk.delay(tenant_id, chunk_id, audio_b64, translate_from, translate_to)
+    else:
+        with threading.Lock():
+            if tenant_id not in audio_stacks:
+                audio_stacks[tenant_id] = queue.Queue()
+            audio_stacks[tenant_id].put((chunk_id, audio_b64, translate_from, translate_to))
+
 
 def get_transcripts(tenant_id):
     """
     Retrieve transcripts for the given tenant.
-    """
-    with threading.Lock():
-        return transcriptsd.get(tenant_id, {})
 
-# Process audio data
+    In Celery mode this reads from the shared Redis-backed store.
+    In legacy mode this reads from the in-process dictionary.
+    """
+    if use_celery:
+        return _store.get_transcripts(tenant_id)
+    else:
+        with threading.Lock():
+            return transcriptsd.get(tenant_id, {})
+
+
+# ---------------------------------------------------------------------------
+# Legacy background processing loop (only used when USE_CELERY=false)
+# ---------------------------------------------------------------------------
+
 def process_audio():
     """
     Continuously process audio chunks for transcription.
+
+    This function runs in a daemon thread when USE_CELERY=false.
+    When USE_CELERY=true this function is never called — Celery
+    workers handle transcription via ``tasks.process_audio_chunk``.
     """
+    if use_celery:
+        return  # Celery workers handle this
+
     while True:
         with threading.Lock():
             # we iterate over alle tenant_ids in the audio_stacks
@@ -162,6 +232,7 @@ def process_audio():
                         else:
                             print(f"Error: {response.status_code}, {response.text}")
                     else:
+                        import torch
                         # Convert int16 to float32 and normalize
                         audio_array = audio_array.astype(np.float32) / 32768.0
                         # Convert to PyTorch tensor
@@ -277,6 +348,11 @@ def clean_old_transcripts():
     """
     Clean up transcripts that are older than two hours.
     """
+    if use_celery:
+        # In Celery mode the periodic task handles this
+        _store.cleanup_old()
+        return
+
     current_time = int(time.time() * 1000)  # Current time in milliseconds
     two_hours_ago = current_time - (2 * 60 * 60 * 1000)  # Two hours ago in milliseconds
     with threading.Lock():
@@ -353,7 +429,7 @@ def merge_and_split_transcripts1(transcripts):
 def translate_with_llm(text, target_language):
     # first try to translate from the cache
     cachekey = target_language + ":" + text
-    cached_translation = translation_cache.get(cachekey, '')
+    cached_translation = _store.get_cached_translation(cachekey) if use_celery else translation_cache_legacy.get(cachekey, '')
     if len(cached_translation) > 0: return cached_translation
 
     # asl a llm to make the translation
@@ -396,7 +472,10 @@ def translate_with_llm(text, target_language):
             try:
                 answer_object = json.loads(content)
                 translation = answer_object.get('translation', '')
-                translation_cache[cachekey] = translation
+                if use_celery:
+                    _store.set_cached_translation(cachekey, translation)
+                else:
+                    translation_cache_legacy[cachekey] = translation
                 return translation
             except json.JSONDecodeError as e:
                 logger.error(f"Error parsing translation response: {str(e)}")
@@ -407,6 +486,9 @@ def translate_with_llm(text, target_language):
         logger.error(f"Error during translation request: {str(e)}")
         return None
 
+# Legacy in-memory translation cache (used when USE_CELERY=false)
+translation_cache_legacy = {}
+
 def translate(text, source_language, target_language):
     """
     Translate the given text from source_language to target_language.
@@ -414,7 +496,10 @@ def translate(text, source_language, target_language):
     global translation_ongoing
     # first try to translate from the cache
     cachekey = source_language + ":" + target_language + ":" + text
-    cached_translation = translation_cache.get(cachekey, '')
+    if use_celery:
+        cached_translation = _store.get_cached_translation(cachekey)
+    else:
+        cached_translation = translation_cache_legacy.get(cachekey, '')
     if len(cached_translation) > 0: return cached_translation
     translation_ongoing = True
     try:
@@ -435,7 +520,10 @@ def translate(text, source_language, target_language):
         translation_text = json_response.get('translation', '')
         if translation_text:
             logger.info(f"Translation took {time.time() - t0} seconds")
-            translation_cache[cachekey] = translation_text
+            if use_celery:
+                _store.set_cached_translation(cachekey, translation_text)
+            else:
+                translation_cache_legacy[cachekey] = translation_text
             translation_ongoing = False
             return translation_text
         else:

--- a/django/transcribe_app/transcript_store.py
+++ b/django/transcribe_app/transcript_store.py
@@ -1,0 +1,198 @@
+# transcribe_app/transcript_store.py
+# (C) Michael Peter Christen 2024
+# Licensed under Apache License Version 2.0
+
+"""
+Pluggable transcript storage backend.
+
+Two implementations are provided:
+  • InMemoryTranscriptStore  – the original dict-based storage (default)
+  • RedisTranscriptStore     – Redis-backed storage required for Celery mode
+
+When USE_CELERY=true the Redis store is used so that both the Django web
+process **and** the Celery worker processes share the same transcript state.
+When USE_CELERY=false (the default) the in-memory store is used, preserving
+the original behaviour with zero additional dependencies.
+
+Usage:
+    from .transcript_store import store
+    store.set_transcript(tenant_id, chunk_id, transcript_event)
+    transcripts = store.get_transcripts(tenant_id)
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend (original behaviour)
+# ---------------------------------------------------------------------------
+
+class InMemoryTranscriptStore:
+    """Thread-safe dictionary-backed transcript store."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        # {tenant_id: {chunk_id: {transcript event dict}}}
+        self._transcripts = {}
+        self._translation_cache = {}
+
+    # -- transcripts --------------------------------------------------------
+
+    def get_transcripts(self, tenant_id):
+        """Return the transcript dict for *tenant_id* (may be empty)."""
+        with self._lock:
+            return self._transcripts.get(tenant_id, {})
+
+    def set_transcript(self, tenant_id, chunk_id, transcript_event):
+        """Create or overwrite a transcript event."""
+        with self._lock:
+            if tenant_id not in self._transcripts:
+                self._transcripts[tenant_id] = {}
+            self._transcripts[tenant_id][chunk_id] = transcript_event
+
+    def get_transcript_event(self, tenant_id, chunk_id):
+        """Return a single transcript event or *None*."""
+        with self._lock:
+            return self._transcripts.get(tenant_id, {}).get(chunk_id)
+
+    def pop_transcript(self, tenant_id, chunk_id):
+        """Remove and return a transcript event."""
+        with self._lock:
+            return self._transcripts.get(tenant_id, {}).pop(chunk_id, None)
+
+    def get_chunk_ids(self, tenant_id):
+        """Return the list of chunk_ids for a tenant."""
+        with self._lock:
+            return list(self._transcripts.get(tenant_id, {}).keys())
+
+    def cleanup_old(self, max_age_ms=2 * 60 * 60 * 1000):
+        """Remove transcript events older than *max_age_ms*."""
+        current_time = int(time.time() * 1000)
+        threshold = current_time - max_age_ms
+        with self._lock:
+            to_delete = []
+            for tenant_id, transcripts in self._transcripts.items():
+                old = [cid for cid in transcripts if cid.isdigit() and int(cid) < threshold]
+                for cid in old:
+                    del transcripts[cid]
+                if not transcripts:
+                    to_delete.append(tenant_id)
+            for tid in to_delete:
+                self._transcripts.pop(tid, None)
+
+    # -- translation cache --------------------------------------------------
+
+    def get_cached_translation(self, cache_key):
+        return self._translation_cache.get(cache_key, '')
+
+    def set_cached_translation(self, cache_key, value):
+        self._translation_cache[cache_key] = value
+
+
+# ---------------------------------------------------------------------------
+# Redis backend (for Celery mode)
+# ---------------------------------------------------------------------------
+
+class RedisTranscriptStore:
+    """
+    Redis-backed transcript store.
+
+    Layout:
+        Hash   transcripts:{tenant_id}   field={chunk_id}  value=JSON
+        String translation_cache:{key}   value=translated text
+        Set    tenant_ids                 all known tenant ids
+    """
+
+    def __init__(self, redis_url=None):
+        import redis
+        url = redis_url or os.getenv('REDIS_URL', 'redis://localhost:6379/1')
+        self._redis = redis.Redis.from_url(url, decode_responses=True)
+        self._prefix = 'susi:'
+        logger.info("RedisTranscriptStore connected to %s", url)
+
+    def _tkey(self, tenant_id):
+        return f"{self._prefix}transcripts:{tenant_id}"
+
+    # -- transcripts --------------------------------------------------------
+
+    def get_transcripts(self, tenant_id):
+        raw = self._redis.hgetall(self._tkey(tenant_id))
+        result = {}
+        for chunk_id, val in raw.items():
+            try:
+                result[chunk_id] = json.loads(val)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return result
+
+    def set_transcript(self, tenant_id, chunk_id, transcript_event):
+        self._redis.hset(self._tkey(tenant_id), chunk_id, json.dumps(transcript_event))
+        self._redis.sadd(f"{self._prefix}tenant_ids", tenant_id)
+
+    def get_transcript_event(self, tenant_id, chunk_id):
+        raw = self._redis.hget(self._tkey(tenant_id), chunk_id)
+        if raw:
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return None
+        return None
+
+    def pop_transcript(self, tenant_id, chunk_id):
+        raw = self._redis.hget(self._tkey(tenant_id), chunk_id)
+        if raw:
+            self._redis.hdel(self._tkey(tenant_id), chunk_id)
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return None
+        return None
+
+    def get_chunk_ids(self, tenant_id):
+        return list(self._redis.hkeys(self._tkey(tenant_id)))
+
+    def cleanup_old(self, max_age_ms=2 * 60 * 60 * 1000):
+        current_time = int(time.time() * 1000)
+        threshold = current_time - max_age_ms
+        tenant_ids = self._redis.smembers(f"{self._prefix}tenant_ids") or set()
+        for tenant_id in tenant_ids:
+            chunk_ids = self._redis.hkeys(self._tkey(tenant_id))
+            old = [cid for cid in chunk_ids if cid.isdigit() and int(cid) < threshold]
+            if old:
+                self._redis.hdel(self._tkey(tenant_id), *old)
+            # remove empty tenant
+            if self._redis.hlen(self._tkey(tenant_id)) == 0:
+                self._redis.srem(f"{self._prefix}tenant_ids", tenant_id)
+
+    # -- translation cache --------------------------------------------------
+
+    def get_cached_translation(self, cache_key):
+        return self._redis.get(f"{self._prefix}translation_cache:{cache_key}") or ''
+
+    def set_cached_translation(self, cache_key, value):
+        # Cache translations for 24 hours
+        self._redis.setex(f"{self._prefix}translation_cache:{cache_key}", 86400, value)
+
+
+# ---------------------------------------------------------------------------
+# Factory — select backend based on USE_CELERY environment variable
+# ---------------------------------------------------------------------------
+
+def _create_store():
+    use_celery = os.getenv('USE_CELERY', 'false').lower() == 'true'
+    if use_celery:
+        try:
+            return RedisTranscriptStore()
+        except Exception as e:
+            logger.warning("Failed to connect to Redis, falling back to in-memory store: %s", e)
+            return InMemoryTranscriptStore()
+    return InMemoryTranscriptStore()
+
+
+store = _create_store()

--- a/django/transcribe_app/views.py
+++ b/django/transcribe_app/views.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from rest_framework.parsers import JSONParser
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
-from .transcribe_utils import get_transcripts, add_to_audio_stack, process_audio, merge_and_split_transcripts, translate, logger
+from .transcribe_utils import get_transcripts, add_to_audio_stack, process_audio, merge_and_split_transcripts, translate, logger, use_celery
 from .serializers import (
     TranscribeInputSerializer,
     TranscribeResponseSerializer,
@@ -29,8 +29,9 @@ import pybars
 import time
 import os
 
-# Start the audio processing thread
-threading.Thread(target=process_audio).start()
+# Start the audio processing thread (legacy mode only)
+if not use_celery:
+    threading.Thread(target=process_audio, daemon=True).start()
 
 def home(request):
     return HttpResponse("Welcome to the Transcription API!")

--- a/django/transcribe_project/__init__.py
+++ b/django/transcribe_project/__init__.py
@@ -1,0 +1,8 @@
+# transcribe_project/__init__.py
+# (C) Michael Peter Christen 2024
+# Licensed under Apache License Version 2.0
+
+# Import the Celery app so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/django/transcribe_project/celery.py
+++ b/django/transcribe_project/celery.py
@@ -1,0 +1,44 @@
+# transcribe_project/celery.py
+# (C) Michael Peter Christen 2024
+# Licensed under Apache License Version 2.0
+
+"""
+Celery application configuration for the transcription project.
+
+When USE_CELERY=true, audio processing tasks are dispatched to Celery workers
+backed by a Redis broker. This replaces the in-process threading.Thread +
+queue.Queue() approach and allows horizontal scaling of Whisper inference
+across multiple worker processes or machines.
+
+Quick start:
+    # 1. Make sure Redis is running (default: localhost:6379)
+    # 2. Set environment variable: export USE_CELERY=true
+    # 3. Start the Celery worker:
+    #    celery -A transcribe_project worker --loglevel=info --concurrency=2
+    # 4. (Optional) Start the periodic beat scheduler:
+    #    celery -A transcribe_project beat --loglevel=info
+"""
+
+import os
+
+from celery import Celery
+
+# Set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'transcribe_project.settings')
+
+app = Celery('transcribe_project')
+
+# Read config from Django settings, using the CELERY_ namespace.
+# e.g.  CELERY_BROKER_URL in settings.py  →  broker_url for Celery.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Autodiscover tasks.py in every installed Django app.
+app.autodiscover_tasks()
+
+# ---------- Periodic tasks (Celery Beat) ----------
+app.conf.beat_schedule = {
+    'cleanup-old-transcripts-every-10-minutes': {
+        'task': 'transcribe_app.tasks.cleanup_old_transcripts_task',
+        'schedule': 600.0,  # every 10 minutes
+    },
+}

--- a/django/transcribe_project/settings.py
+++ b/django/transcribe_project/settings.py
@@ -125,3 +125,27 @@ STATIC_ROOT   = BASE_DIR / 'staticfiles'
 STATICFILES_DIRS = [BASE_DIR / 'static']
 APPEND_SLASH = False # most stupid default setting ever
 DEBUG = True
+
+# ---------------------------------------------------------------------------
+# Celery + Redis configuration
+# ---------------------------------------------------------------------------
+# Set USE_CELERY=true to replace the in-process threading.Thread queue with
+# Celery workers backed by Redis.  When false (default) the original
+# threading-based approach is used and no Redis dependency is required.
+
+USE_CELERY = os.getenv('USE_CELERY', 'false').lower() == 'true'
+
+# Redis connection URL (used as both Celery broker and transcript store)
+REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+
+# Celery settings (only relevant when USE_CELERY=true)
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', REDIS_URL)
+CELERY_RESULT_BACKEND = os.getenv('CELERY_RESULT_BACKEND', REDIS_URL)
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+CELERY_TIMEZONE = 'UTC'
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 120          # hard kill after 2 minutes
+CELERY_TASK_SOFT_TIME_LIMIT = 90      # raise SoftTimeLimitExceeded after 90s
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1 # one task at a time per worker (GPU bound)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+celery[redis]
 django
 django-cors-headers
 djangorestframework
@@ -7,4 +8,5 @@ mkdocs-bootswatch
 openai-whisper
 pyaudio
 pybars3
+redis
 requests


### PR DESCRIPTION
…n scaling

Replace the in-process queue.Queue() + threading.Thread audio processing loop with a Celery distributed task queue backed by Redis.

New files:
- django/transcribe_project/celery.py: Celery app bootstrap with autodiscovery and Celery Beat periodic schedule (cleanup every 10 min)
- django/transcribe_app/tasks.py: Three idempotent Celery tasks — process_audio_chunk (transcription, acks_late, max_retries=3), translate_transcript, cleanup_old_transcripts_task
- django/transcribe_app/transcript_store.py: Pluggable storage backend — InMemoryTranscriptStore (legacy, default) and RedisTranscriptStore (Celery mode, Redis hashes keyed per tenant_id)

Modified files:
- django/transcribe_project/__init__.py: Import Celery app so shared_task decorators bind correctly (standard Django-Celery pattern)
- django/transcribe_project/settings.py: CELERY_* config block driven by environment variables (CELERY_BROKER_URL, CELERY_RESULT_BACKEND, etc.)
- django/transcribe_app/transcribe_utils.py: Dual-mode dispatch — add_to_audio_stack() dispatches Celery task when USE_CELERY=true, get_transcripts() reads from pluggable store; legacy code preserved
- django/transcribe_app/views.py: Conditional thread start (legacy only)
- django/transcribe_app/apps.py: Conditional thread start in ready()
- requirements.txt: Add celery[redis] and redis

Backward compatible: USE_CELERY defaults to false — existing deployments run identically with no Redis dependency required.

Closes #N/A