### PR TITLE
Implement abstract translation provider registry with tests

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,12 @@
+
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry, register_provider, available_providers
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+    "register_provider",
+    "available_providers",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,77 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class TranslationProvider(ABC):
+    """
+    Abstract base class for all translation and LLM providers.
+
+    To ensure fast startup time are strictly deferred until a 
+    translation is actually requested, rather than loading at import time.
+
+    We also enforce tenant isolation by making sure each instance holds its own
+    distinct configuration without relying on shared class-level state. 
+    
+    the translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings like, an LLM's temperature or DeepL's formality—without ever having 
+    to alter the base signature.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initializing the provider with tenant-specific configuration,
+        this can include API keys, model paths, or any other settings required 
+        for the provider to function.
+        """
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translate text from source_lang to target_lang
+        **kwargs: Optional provider specific parameters('temperature' for LLMs, 
+        'formality' for DeepL)
+        """
+        ...
+
+    #health check to ensure provider is ready to serve requests
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the provider is healthy and ready to serve requests
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """
+        The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
+        Used heavily in logging, telemetry, and registry lookups
+        """
+        ...

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,134 @@
+"""
+Per-tenant provider registry for Susi Translator,
+This module manages the lifecycle of translation 
+providers
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+
+logger = logging.getLogger(__name__)
+
+# Registry of provider factories.
+# Callable[[Dict[str, Any]], TranslationProvider] means it expects a config dict 
+# and returns a TranslationProvider instance
+_PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
+
+
+def register_provider(
+    name: str, 
+    factory: Callable[[Dict[str, Any]], TranslationProvider]
+) -> None:
+    """
+    Register a provider factory under a canonical name
+    """
+    _PROVIDER_FACTORIES[name] = factory
+    logger.debug(f"Registered translation provider: {name}")
+
+
+def available_providers() -> List[str]:
+    """Return list of all registered provider names"""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
+class ProviderRegistry:
+    """
+    Per-tenant provider registry. One shared instance should be created
+    at module load time in transcribe_server.py and used across all requests
+    """
+
+    def __init__(self):
+        # tenant_id -> { "provider_name": str, "config": dict, "instance": Optional[TranslationProvider] }
+        self._tenants: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def configure(
+        self,
+        tenant_id: str,
+        provider_name: str,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Configure a provider for a tenant session.
+        """
+        if provider_name not in _PROVIDER_FACTORIES:
+            raise ValueError(
+                f"Unknown provider '{provider_name}'. "
+                f"Available: {available_providers()}"
+            )
+
+        # Bundle the config as expected by base.py
+        config_dict = {"api_key": api_key, **kwargs}
+
+        with self._lock:
+            self._tenants[tenant_id] = {
+                "provider_name": provider_name,
+                "config": config_dict,
+                "instance": None,  # instantiated lazily on first use
+            }
+            
+        logger.info(
+            f"Configured provider '{provider_name}' for tenant '{tenant_id}'"
+        )
+
+    def translate(
+        self,
+        tenant_id: str,
+        text: str,
+        source_lang: str,
+        target_lang: str,
+        **kwargs: Any
+    ) -> Optional[str]:
+        """
+        Translate text for a given tenant using their configured provider.
+        """
+        #Fast, lock-free read to get the tenant entry
+        entry = self._tenants.get(tenant_id)
+        if entry is None:
+            return None  # no translation configured for this tenant
+
+        #Lazy Instantiation with Double-Checked Locking
+        if entry["instance"] is None:
+            with self._lock:
+                
+                if entry["instance"] is None:
+                    provider_name = entry["provider_name"]
+                    factory = _PROVIDER_FACTORIES[provider_name]
+                    
+                    try:
+                        # Pass the bundled config dict to match base.py
+                        instance = factory(entry["config"])
+                        entry["instance"] = instance
+                        logger.info(f"Lazily instantiated '{provider_name}' for tenant '{tenant_id}'")
+                    except Exception as e:
+                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        raise ProviderConfigError(f"Provider initialization failed: {e}")
+
+        provider: TranslationProvider = entry["instance"]
+
+        if not provider.is_available():
+            logger.warning(
+                f"Provider '{provider.provider_name}' is not available "
+                f"for tenant '{tenant_id}'"
+            )
+            return None
+
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)
+
+    def remove(self, tenant_id: str) -> None:
+        """Remove provider config for a tenant"""
+        with self._lock:
+            self._tenants.pop(tenant_id, None)
+
+    def get_provider_name(self, tenant_id: str) -> Optional[str]:
+        """Return the configured provider name for a tenant, or None."""
+        with self._lock:
+            entry = self._tenants.get(tenant_id)
+            return entry["provider_name"] if entry else None

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,216 @@
+"""
+Tests covers the translation provider architecture, ensuring that the 
+abstract interface is correctly defined and that the provider registry 
+behaves as expected
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+import pytest
+
+from providers.base import TranslationProvider, TranslationError, ProviderConfigError
+from providers.registry import (
+    ProviderRegistry,
+    register_provider,
+    available_providers,
+)
+
+# Minimal concrete providers for testing 
+
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged. Tracks instantiation count."""
+
+    instantiation_count = 0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # enforces threads to collide in the concurrency test
+        # to guarantee the double-checked lock is actually tested
+        time.sleep(0.05) 
+        EchoProvider.instantiation_count += 1
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
+class FailingProvider(TranslationProvider):
+    """Raises TranslationError on every translate() call."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("intentional failure")
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "failing"
+
+class ConfigCapturingProvider(TranslationProvider):
+    """Stores the config it receives so tests can assert on it."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.received_config = dict(self.config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "config_capturing"
+
+
+
+#Fixtures
+
+@pytest.fixture(autouse=True)
+def clean_factories():
+    with patch("providers.registry._PROVIDER_FACTORIES", {}) as mock_dict:
+        yield mock_dict
+
+@pytest.fixture
+def registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+#Abstract interface tests
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+
+#Registration tests
+class TestProviderRegistration:
+    def test_register_and_list(self) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        assert "echo" in available_providers()
+
+
+
+#Registry configuration tests
+class TestRegistryConfigure:
+    def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        registry.configure("tenant1", "config_capturing", api_key="secret-key")
+        
+        registry.translate("tenant1", "hello", "en", "de")
+        instance = registry._tenants["tenant1"]["instance"]
+        assert instance.received_config["api_key"] == "secret-key"
+
+
+#Lazy instantiation tests
+
+class TestLazyInstantiation:
+    def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("tenant1", "echo")
+        
+        # Instance should be None before translation
+        assert registry._tenants["tenant1"]["instance"] is None
+        
+        registry.translate("tenant1", "hello", "en", "de")
+        
+        # Instance should exist after translation
+        assert registry._tenants["tenant1"]["instance"] is not None
+
+
+
+
+# Translation & Multi-tenant tests
+
+class TestMultiTenantIsolation:
+    def test_tenant_config_is_isolated(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        
+        registry.configure("tenant_a", "config_capturing", api_key="key-a")
+        registry.configure("tenant_b", "config_capturing", api_key="key-b")
+
+        registry.translate("tenant_a", "x", "en", "de")
+        registry.translate("tenant_b", "x", "en", "de")
+
+        instance_a = registry._tenants["tenant_a"]["instance"]
+        instance_b = registry._tenants["tenant_b"]["instance"]
+
+        assert instance_a.received_config["api_key"] == "key-a"
+        assert instance_b.received_config["api_key"] == "key-b"
+        assert instance_a is not instance_b
+
+
+
+# Thread safety test
+class TestThreadSafety:
+    def test_concurrent_translate_same_tenant(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating for the same tenant must not bypass the lock."""
+        EchoProvider.instantiation_count = 0
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("tenant1", "echo")
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                # Due to the time.sleep in EchoProvider, all 20 threads will 
+                # smash into the lock simultaneously here.
+                result = registry.translate("tenant1", "hello", "en", "de")
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert all(r == "hello" for r in results)
+        
+        # PROOF: Even with 20 threads colliding, the model was only loaded into RAM exactly once.
+        assert EchoProvider.instantiation_count == 1

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -87,6 +87,24 @@ class ConfigCapturingProvider(TranslationProvider):
     @property
     def provider_name(self):
         return "config_capturing"
+    
+
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them"""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
 
 
 
@@ -160,6 +178,28 @@ class TestLazyInstantiation:
         assert registry._tenants["tenant1"]["instance"] is not None
 
 
+
+# Translation tests
+class TestTranslate:
+    def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
+        """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
+        register_provider(
+            "kwargs_capturing", 
+            lambda config: KwargsCapturingProvider(config)
+        )
+        registry.configure("tenant1", "kwargs_capturing")
+        
+        registry.translate(
+            "tenant1", 
+            "hello", 
+            "en", 
+            "de", 
+            temperature=0.3, 
+            formality="informal"
+        )
+        
+        instance = registry._tenants["tenant1"]["instance"]
+        assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
 
 
 # Translation & Multi-tenant tests

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -201,6 +201,28 @@ class TestTranslate:
         instance = registry._tenants["tenant1"]["instance"]
         assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
 
+    def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
+        """Ensure runtime TranslationErrors from the provider are properly propagated."""
+        register_provider("failing", lambda config: FailingProvider(config))
+        registry.configure("tenant1", "failing")
+        
+        # The provider is designed to fail when translate is called
+        with pytest.raises(TranslationError, match="intentional failure"):
+            registry.translate("tenant1", "hello", "en", "de")
+
+    def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
+        """Ensure errors during lazy initialization are caught and wrapped correctly."""
+        def bad_factory(config):
+            raise RuntimeError("missing heavy ML weights")
+
+        register_provider("broken", bad_factory)
+        registry.configure("tenant1", "broken")
+        
+        # The initialization happens lazily during the first translate call.
+        # It should catch the RuntimeError and wrap it in a ProviderConfigError.
+        with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
+            registry.translate("tenant1", "hello", "en", "de")
+
 
 # Translation & Multi-tenant tests
 


### PR DESCRIPTION
this PR resolves issue #57 
Previously, translation logic was hardcoded, which blocked organizers from choosing their own models (external APIs or, local) and caused the server to hang on startup while loading heavy weights. This PR builds the underlying framework to fix that, acting as a flexible system for any translation service.

What changed:

- `TranslationProvider` base class: Sets a standard interface so, any models (DeepL, OpenAI, custom local models) can be easily plugged in.

- Thread safe ProviderRegistry: Keeps tenant configurations isolated per-session. I used double-checked locking so multiple concurrent requests for the same event won't accidentally initialize a model twice.

- Lazy Loading: The registry strictly defers loading any heavy dependencies (like transformers) until the exact moment translate() is first called.

- Test Suite: Added comprehensive pytest coverage using lightweight mock providers to test the registry logic and threading locks 

Note: Any specific provider implementations included in this branch are just the first "plugins" to validate the architecture. The framework is now completely agnostic, allowing organizers to define whatever model fits their constraints.

I intentionally left the Flask API route (/configure_provider) out of this PR to keep the review small and focused strictly on the architecture. I'll open a separate sub-issue to handle the API route wiring next.

## Summary by Sourcery

Introduce a pluggable translation provider architecture with a per-tenant registry and lazy instantiation.

New Features:
- Define an abstract TranslationProvider interface with standardized error types for translation backends.
- Add a per-tenant ProviderRegistry that supports registration, configuration, and lazy loading of translation providers.

Enhancements:
- Expose translation provider primitives via the providers package for easier integration across the codebase.

Tests:
- Add pytest coverage for the provider interface, registry configuration, lazy instantiation, multi-tenant isolation, and thread safety of concurrent translations.