### PR TITLE
feat(core): implementation of translation provider architecture to support multiple models as per config rather than hardcoded models

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,9 @@
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -16,7 +16,7 @@ class TranslationError(Exception):
     """Base exception for all translation related failures"""
 
 
-class ProviderConfigError(Exception):
+class ProviderConfigError(TranslationError):
     """Raised when a provider is initialized with missing or malformed configuration"""
 
 

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -20,6 +20,11 @@ class ProviderConfigError(Exception):
     """Raised when a provider is initialized with missing or malformed configuration"""
 
 
+class ProviderUnavailableError(TranslationError):
+    """Raised when a provider is registered but currently unavailable"""
+    pass
+
+
 class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,70 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class TranslationProvider(ABC):
+    """
+    Abstract base class for all translation and LLM providers.
+
+    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    to alter the base signature.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the provider with necessary configuration.
+        This can include API keys, model paths, or any other settings required 
+        for the provider to function.
+        """
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translate text from source_lang to target_lang.
+        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
+        'formality' for DeepL).
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the provider is healthy and ready to serve requests.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """
+        The canonical, machine-readable name of the provider,
+        Use in logging, telemetry, and registry lookups.
+        """
+        pass

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
-from .base import TranslationProvider, TranslationError , ProviderUnavailableError
+from .base import TranslationProvider, ProviderUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class ProviderRegistry:
         if provider.provider_name in self._providers:
             raise ValueError(f"Provider '{provider.provider_name}' is already registered")
         self._providers[provider.provider_name] = provider
-        logger.info(f"Registered provider: {provider.provider_name}")
+        logger.info("Registered provider: %s", provider.provider_name)
 
     def get_provider(self, provider_name: str) -> TranslationProvider:
         """
@@ -52,8 +52,10 @@ class ProviderRegistry:
         
         if not provider.is_available():
             raise ProviderUnavailableError(
-            f"Provider '{provider_name}' is currently unavailable"
+                f"Provider '{provider_name}' is currently unavailable"
         )
             
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)
+    
+default_registry = ProviderRegistry()

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,55 @@
+"""
+Basic provider registry for Translator,
+This manages the registration and retrieval of translation providers
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .base import TranslationProvider, TranslationError
+
+logger = logging.getLogger(__name__)
+
+class ProviderRegistry:
+    """
+    A simple registry to hold instantiated translation providers.
+    """
+
+    def __init__(self):
+        self._providers: Dict[str, TranslationProvider] = {}
+
+    def register(self, provider: TranslationProvider) -> None:
+        """
+        Registers an already-instantiated translation provider
+        """
+        self._providers[provider.provider_name] = provider
+        logger.info(f"Registered translation provider: {provider.provider_name}")
+
+    def get_provider(self, provider_name: str) -> TranslationProvider:
+        """
+        Retrieves a provider by name, Raises ValueError if the provider is not registered.
+        """
+        if provider_name not in self._providers:
+            raise ValueError(f"Provider '{provider_name}' is not registered.")
+        return self._providers[provider_name]
+
+    def translate(
+        self, 
+        provider_name: str, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translates text using the specified provider
+        """
+        provider = self.get_provider(provider_name)
+        
+        if not provider.is_available():
+            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict
 
-from .base import TranslationProvider, TranslationError
+from .base import TranslationProvider, TranslationError , ProviderUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +24,10 @@ class ProviderRegistry:
         """
         Registers an already-instantiated translation provider
         """
+        if provider.provider_name in self._providers:
+            raise ValueError(f"Provider '{provider.provider_name}' is already registered")
         self._providers[provider.provider_name] = provider
-        logger.info(f"Registered translation provider: {provider.provider_name}")
+        logger.info(f"Registered provider: {provider.provider_name}")
 
     def get_provider(self, provider_name: str) -> TranslationProvider:
         """
@@ -49,7 +51,9 @@ class ProviderRegistry:
         provider = self.get_provider(provider_name)
         
         if not provider.is_available():
-            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            raise ProviderUnavailableError(
+            f"Provider '{provider_name}' is currently unavailable"
+        )
             
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -4,6 +4,7 @@ basic registry functionality for susi_translator.
 """
 
 from __future__ import annotations
+
 import pytest
 
 from providers.base import TranslationProvider, TranslationError, ProviderUnavailableError
@@ -22,6 +23,7 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
+
 class UnavailableProvider(TranslationProvider):
     """Always reports itself as unavailable."""
     def translate(self, text, source_lang, target_lang, **kwargs):
@@ -33,6 +35,7 @@ class UnavailableProvider(TranslationProvider):
     @property
     def provider_name(self):
         return "unavailable"
+
 
 class KwargsCapturingProvider(TranslationProvider):
     """Stores the kwargs passed to translate() so tests can assert on them."""

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,116 @@
+"""
+Tests covering the base translation provider architecture and 
+basic registry functionality for susi_translator.
+"""
+
+from __future__ import annotations
+import pytest
+
+from providers.base import TranslationProvider, TranslationError
+from providers.registry import ProviderRegistry
+
+#concrete providers
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
+
+
+#Abstract interfaces
+
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+#Registry Tests
+
+class TestBasicRegistry:
+    def test_register_and_retrieve(self):
+        registry = ProviderRegistry()
+        provider = EchoProvider()
+        
+        registry.register(provider)
+        retrieved = registry.get_provider("echo")
+        
+        assert retrieved is provider
+
+    def test_unregistered_provider_raises_error(self):
+        registry = ProviderRegistry()
+        with pytest.raises(ValueError, match="is not registered"):
+            registry.get_provider("missing")
+
+    def test_translate_routes_correctly(self):
+        registry = ProviderRegistry()
+        registry.register(EchoProvider())
+        
+        result = registry.translate("echo", "hello", "en", "es")
+        assert result == "hello"
+
+    def test_translate_checks_availability(self):
+        registry = ProviderRegistry()
+        registry.register(UnavailableProvider())
+        
+        # It should check `is_available()` and throw an error before trying to translate
+        with pytest.raises(RuntimeError, match="currently unavailable"):
+            registry.translate("unavailable", "hello", "en", "es")
+
+    def test_translate_forwards_kwargs(self):
+        registry = ProviderRegistry()
+        provider = KwargsCapturingProvider()
+        registry.register(provider)
+        
+        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
+        assert provider.last_kwargs == {"temperature": 0.7}

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -6,7 +6,7 @@ basic registry functionality for susi_translator.
 from __future__ import annotations
 import pytest
 
-from providers.base import TranslationProvider, TranslationError
+from providers.base import TranslationProvider, TranslationError, ProviderUnavailableError
 from providers.registry import ProviderRegistry
 
 #concrete providers
@@ -87,6 +87,13 @@ class TestBasicRegistry:
         
         assert retrieved is provider
 
+    def test_duplicate_registration_raises_error(self):
+        registry = ProviderRegistry()
+        registry.register(EchoProvider())
+
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register(EchoProvider())  
+
     def test_unregistered_provider_raises_error(self):
         registry = ProviderRegistry()
         with pytest.raises(ValueError, match="is not registered"):
@@ -102,9 +109,8 @@ class TestBasicRegistry:
     def test_translate_checks_availability(self):
         registry = ProviderRegistry()
         registry.register(UnavailableProvider())
-        
-        # It should check `is_available()` and throw an error before trying to translate
-        with pytest.raises(RuntimeError, match="currently unavailable"):
+
+        with pytest.raises(ProviderUnavailableError, match="currently unavailable"):
             registry.translate("unavailable", "hello", "en", "es")
 
     def test_translate_forwards_kwargs(self):


### PR DESCRIPTION
This PR establishes the abstract translation provider architecture for issue fixes #60

Changes:
- Added TranslationProvider base class and custom exceptions in base.py.
- Added a basic, single-instance ProviderRegistry, in next PR will modify it to handle multi-tenant
- Added a comprehensive test suite using mock providers.

Note: Lazy loading and multi-tenant isolation are intentionally excluded from this PR and will be introduced in subsequent PRs to keep reviews atomic.

## Reviewer's Guide:
This PR lays the foundational architecture for the translation provider system. There are no user-facing API endpoints in this step. The focus is entirely on establishing a robust, extensible Python base so we can easily plug in external models in subsequent steps.
since this is a structural PR, please focus your review on the design patterns, and extensibility.

***How to Test***
Because this PR introduces structural foundation architecture rather than user-facing API routes, the verification is entirely handled via the automated unit test suite
- Sync your environment:

```bash
uv sync
```

- Run the provider architecture test file: 
Navigate to the flask/tests directory and execute:
```bash
uv run pytest test_provider_architecture.py
```

***expected outcome***:

<img width="1900" height="223" alt="image" src="https://github.com/user-attachments/assets/4d333d76-e3ab-43b7-ba5d-07b461beb3b5" />

