### PR TITLE
feat: Add YouTube as a 5th client-side audio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,6 @@ curl "http://localhost:5040/list_transcripts?source=youtube"
 curl "http://localhost:5040/pop_first_transcript?source=youtube"
 ```
 
-The `youtube` source resolves the supplied URL via yt-dlp (default format
-selector `bestaudio/best`, override with `--format`), pipes the resulting
-direct media URL through ffmpeg, and auto-reconnects on transient stream
-interruptions with capped exponential backoff. The host must be a
-recognised YouTube domain; arbitrary `https://...` URLs are rejected.
-
 ### YouTube authentication ("Sign in to confirm you're not a bot")
 
 YouTube increasingly returns
@@ -116,9 +110,7 @@ policy, not a bug; yt-dlp itself can't bypass it. Pass cookies from a
 logged-in YouTube session using one of these mutually exclusive flags:
 
 ```bash
-# Option A: read cookies straight from your browser (does NOT work
-# reliably on WSL because the Windows browser's cookie store sits
-# outside the WSL filesystem):
+# Option A: read cookies straight from your browser:
 uv run python flask/audio_grabber.py youtube \
     --url https://www.youtube.com/watch?v=EXAMPLE_ID \
     --cookies-from-browser chrome

--- a/README.md
+++ b/README.md
@@ -63,6 +63,78 @@ Flask backend bind / safety:
 
 `requirements.txt` is kept for compatibility, but `uv sync` is the supported install flow.
 
+## Audio grabber (client-side ingestion)
+
+The grabber under `flask/audio_grabber.py` captures audio from one of five
+sources and streams it to the transcription server. Each source runs
+client-side; the server only ever receives already-decoded base64 PCM via
+`POST /transcribe`.
+
+| Source    | Backend                 | Extra requirements                |
+| --------- | ----------------------- | --------------------------------- |
+| `mic`     | PyAudio                 | a working input device            |
+| `file`    | pydub + ffmpeg          | ffmpeg on PATH                    |
+| `url`     | ffmpeg                  | ffmpeg on PATH                    |
+| `stdin`   | raw PCM passthrough     | none                              |
+| `youtube` | yt-dlp + ffmpeg         | ffmpeg on PATH (yt-dlp via `uv sync`) |
+
+Examples:
+
+```bash
+uv run python flask/audio_grabber.py mic
+uv run python flask/audio_grabber.py file --path talk.mp3 --realtime
+uv run python flask/audio_grabber.py url --url https://example.com/live.m3u8
+uv run python flask/audio_grabber.py youtube --url https://www.youtube.com/live/EXAMPLE_ID
+ffmpeg -i input.wav -f s16le -ac 1 -ar 16000 - | \
+    uv run python flask/audio_grabber.py stdin
+```
+
+Read the resulting transcripts back via `?source=<name>`:
+
+```bash
+curl "http://localhost:5040/list_transcripts?source=youtube"
+curl "http://localhost:5040/pop_first_transcript?source=youtube"
+```
+
+The `youtube` source resolves the supplied URL via yt-dlp (default format
+selector `bestaudio/best`, override with `--format`), pipes the resulting
+direct media URL through ffmpeg, and auto-reconnects on transient stream
+interruptions with capped exponential backoff. The host must be a
+recognised YouTube domain; arbitrary `https://...` URLs are rejected.
+
+### YouTube authentication ("Sign in to confirm you're not a bot")
+
+YouTube increasingly returns
+
+```
+ERROR: [youtube] <id>: Sign in to confirm you're not a bot.
+       Use --cookies-from-browser or --cookies for the authentication.
+```
+
+for requests from data-center IPs, VPNs, or WSL. This is a YouTube
+policy, not a bug; yt-dlp itself can't bypass it. Pass cookies from a
+logged-in YouTube session using one of these mutually exclusive flags:
+
+```bash
+# Option A: read cookies straight from your browser (does NOT work
+# reliably on WSL because the Windows browser's cookie store sits
+# outside the WSL filesystem):
+uv run python flask/audio_grabber.py youtube \
+    --url https://www.youtube.com/watch?v=EXAMPLE_ID \
+    --cookies-from-browser chrome
+
+# Option B: export cookies.txt from your browser (Netscape format,
+# via a 'Get cookies.txt LOCALLY' or similar extension while logged
+# into youtube.com), then point --cookies at the file. This is the
+# reliable path on WSL:
+uv run python flask/audio_grabber.py youtube \
+    --url https://www.youtube.com/watch?v=EXAMPLE_ID \
+    --cookies /path/to/youtube-cookies.txt
+```
+
+Treat the cookies file like a credential — it grants access to your
+YouTube account. Do not commit it to git.
+
 ## Tests
 
 A pytest suite for the Flask backend lives under `flask/tests/`.

--- a/flask/README.md
+++ b/flask/README.md
@@ -1,0 +1,98 @@
+## What the Flask App Is
+
+A real-time speech-to-text (transcription) HTTP API built with Flask + flask-restx. It accepts streamed audio chunks, transcribes them via Whisper, and exposes REST endpoints for clients to poll/consume the resulting text.
+
+---
+
+## High-Level Architecture
+
+```
+┌─────────────┐  POST /session   ┌──────────────────────────┐
+│ audio_      │  POST /transcribe│  transcribe_server.py    │
+│ grabber.py  │ ───────────────> │  (Flask + flask-restx)   │
+│ (mic/file/  │                  │                          │
+│  url/stdin  │                  │  ┌────────────────────┐  │
+│  /youtube)  │                  │  │ audio_stack queue  │  │
+└─────────────┘                  │  └─────────┬──────────┘  │
+                                 │            ▼             │
+                                 │  ┌────────────────────┐  │      Whisper
+                                 │  │ process_audio()    │──┼──▶  (local model
+                                 │  │ worker thread      │  │       OR whisper.cpp
+                                 │  └─────────┬──────────┘  │       HTTP server)
+                                 │            ▼             │
+                                 │  transcriptd (in-memory) │
+                                 │   tenant -> chunk -> txt │
+                                 └──────────────────────────┘
+                                              ▲
+                  GET /list_transcripts, /get_first_transcript, etc.
+```
+
+---
+
+## How It Works
+
+**1. Producer side (`audio_grabber.py` / `audio_sources.py`)**
+
+Grabs ~1s frames of 16 kHz / 16-bit / mono PCM from a mic, file, URL, stdin, or YouTube. Accumulates up to ~10s buffers (resets on silence) and POSTs each as base64 to `/transcribe`.
+
+**2. Server side (`transcribe_server.py`)**
+
+- `/transcribe` only enqueues `(tenant_id, chunk_id, audio_b64)` onto an in-memory `queue.Queue` (`audio_stack`) and returns immediately — non-blocking.
+- A background worker thread (`process_audio`) pulls items, decodes base64 → int16 numpy → float32, then either runs Whisper locally (small/medium model selected by queue depth) or POSTs WAV bytes to whisper.cpp's `/inference` HTTP server.
+- Results land in an in-memory dict `transcriptd[tenant_id][chunk_id] = {'transcript': ...}`, guarded by a single `threading.Lock`.
+
+---
+
+## Key Design Pieces
+
+**Sessions and source aliases.**
+Instead of forcing clients to track UUIDs, `POST /session?source=mic|file|url|stdin|youtube` mints a tenant UUID and registers it as "the latest session for that source." Read endpoints accept `?source=mic`, which resolves to that current tenant ID. Sessions expire after `SESSION_TTL_SECONDS` (default 7200s).
+
+**Pluggable Whisper backend.**
+`WHISPER_SERVER_USE=true` uses an external whisper.cpp HTTP server (no torch/whisper import — keeps the module light); otherwise it lazily imports torch + openai-whisper and loads two local models (`WHISPER_MODEL_FAST`, `WHISPER_MODEL_SMART`).
+
+**Queue dedup.**
+`_next_payload()` peeks ahead in the queue and drops superseded duplicates of the same `(tenant_id, chunk_id)` (with proper `task_done()` accounting) so only the most recent version of an extending chunk gets transcribed.
+
+**Validation filter.**
+`is_valid()` discards Whisper hallucinations like "thank you", "bye!", "thanks for watching", certain Korean fragments, transcripts with 40+ char "words," or pure non-ASCII output.
+
+**Sentence reflow.**
+`merge_and_split_transcripts()` re-flows chunked text onto sentence boundaries (`.!?`), redistributing the merged output back onto `chunk_id`s.
+
+**Garbage collection.**
+`clean_old_transcripts()` runs after every chunk and evicts chunks older than 2 hours and any tenants that become empty.
+
+**Safe defaults.**
+Binds `127.0.0.1` only by default; `FLASK_DEBUG=false` (the Werkzeug debugger over network = RCE — explicit warning if misconfigured). CORS origins are env-driven, defaulting to localhost only.
+
+---
+
+## REST Endpoints
+
+All endpoints are available under `/swagger`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/session` | Mint a tenant UUID for a source (`mic`/`file`/`url`/`stdin`/`youtube`) |
+| `POST` | `/transcribe` | Submit a base64 audio chunk for async processing |
+| `GET` | `/get_transcript` | Fetch transcript for a specific `chunk_id` |
+| `GET` | `/get_first_transcript` | First transcript ≥ `from` |
+| `GET` | `/get_latest_transcript` | Latest transcript < `until` |
+| `DELETE` / `GET` | `/pop_first_transcript` | Read + remove first (`GET` deprecated) |
+| `DELETE` / `GET` | `/pop_latest_transcript` | Read + remove latest (`GET` deprecated) |
+| `DELETE` / `GET` | `/delete_transcript` | Delete by `chunk_id` (`GET` deprecated) |
+| `GET` | `/list_transcripts` | All transcripts in `[from, until]` |
+| `GET` | `/transcripts_size` | Count of transcripts in `[from, until]` |
+
+All read endpoints accept either `?tenant_id=<uuid>` or `?source=<name>`, plus `?sentences=true` to return text re-flowed at sentence boundaries.
+
+---
+
+## Other Files in `flask/`
+
+- **`audio_grabber.py`** — CLI client orchestrator (subcommands `mic`, `file`, `url`, `stdin`, `youtube`).
+- **`audio_sources.py`** — `AudioSource` ABC + four concrete implementations; `URLSource` has explicit security validation (rejects `file://`, `concat:`, leading `-` to block ffmpeg arg injection).
+- **`transcribe_listener.html`, `transcribe_evaluation.html`, `audio_grabber.html`** — browser UIs that hit the same API.
+- **`tests/`** — pytest suite (`conftest.py` pins `WHISPER_SERVER_USE=true` so tests don't download multi-hundred-MB models).
+- **`speech.pcm`, `speech.mp3`, `tone.pcm`** — sample audio for manual smoke testing.

--- a/flask/audio_grabber.py
+++ b/flask/audio_grabber.py
@@ -1,14 +1,10 @@
 """
-SUSI Translator audio grabber (refactored orchestrator).
+SUSI Translator audio grabber
 
 Reads audio from one of five sources (microphone, file, URL, stdin,
 YouTube), buffers up to ~10 seconds while resetting on silence, and POSTs
 base64-encoded chunks to the transcription server's ``/transcribe``
 endpoint.
-
-The POST body shape is unchanged from the original implementation::
-
-    { "chunk_id": str, "audio_b64": str, "tenant_id": str }
 
 System requirements
 -------------------
@@ -19,22 +15,12 @@ System requirements
 - ``youtube`` : the ``yt-dlp`` Python package + the ``ffmpeg`` binary on
                 PATH.
 
-Tenant IDs (auto-managed)
--------------------------
-The grabber never asks the user for a tenant id. On startup it calls
-``POST /session`` with the chosen subcommand (``mic``/``file``/``url``/
-``stdin``/``youtube``); the server mints a fresh tenant_id (uuid) and
-records it as the latest session for that source.
+To fetch transcripts, curl with ``?source=<name>`` 
 
-To fetch transcripts, curl with ``?source=<name>`` instead of
-``?tenant_id=...``::
-
-    curl "http://localhost:5040/pop_first_transcript?source=mic"
+    curl "http://localhost:5040/list_transcripts?source=mic"
     curl "http://localhost:5040/pop_first_transcript?source=youtube"
 
-The server resolves ``source=mic`` to "the most recent mic session", so
-each fresh run gives you a clean bucket of transcripts under that fixed
-curl command. ``--tenant <id>`` is still accepted as an explicit
+``--tenant <id>`` is still accepted as an explicit
 override (e.g. for reconnecting to a known session id).
 
 Examples
@@ -74,7 +60,6 @@ from audio_sources import (
 )
 
 
-# --- Audio / chunking constants (kept identical to the original grabber) ---
 RATE: int = 16000
 SAMPLE_WIDTH: int = 2  # 16-bit
 BUFFER_SIZE: int = 2 * 10 * RATE  # bytes -> 10 seconds of audio
@@ -84,24 +69,8 @@ DEFAULT_SERVER: str = "http://localhost:5040"
 VALID_SOURCES = ("mic", "file", "url", "stdin", "youtube")
 
 
-# ---------------------------------------------------------------------------
-# Silence detection (absolute-peak variant of the original is_silent)
-# ---------------------------------------------------------------------------
 
-def _is_silent(pcm_bytes: bytes) -> bool:
-    """
-    Return True if the loudest sample in ``pcm_bytes`` is below
-    ``SILENCE_THRESHOLD``.
-
-    Behaviour note
-    --------------
-    The original ``AudioGrabber.is_silent`` (see ``audio_grabber.html``) used
-    ``Math.max(...data)``, i.e. the signed maximum, which would mis-classify
-    buffers whose loudest excursions are negative as "silent". This
-    implementation intentionally uses ``max(abs(s) for s in samples)`` so
-    that loud negative excursions count too. Callers that depend on strict
-    bit-for-bit parity with the JS check should be aware of this difference.
-    """
+def _is_silent(pcm_bytes: bytes) -> bool: # Return True if the loudest sample in ``pcm_bytes`` is below ``SILENCE_THRESHOLD``.
     if not pcm_bytes:
         return True
     n_samples = len(pcm_bytes) // SAMPLE_WIDTH
@@ -111,22 +80,11 @@ def _is_silent(pcm_bytes: bytes) -> bool:
     peak = max(abs(s) for s in samples)
     return peak < SILENCE_THRESHOLD
 
-
-# ---------------------------------------------------------------------------
-# Uploader
-# ---------------------------------------------------------------------------
-
-def _build_session() -> requests.Session:
-    """Build a requests Session with retry/backoff for transient 5xx errors."""
+def _build_session() -> requests.Session: # Build a requests Session with retry/backoff for transient 5xx errors.
     retry_policy = Retry(
         total=5,
         backoff_factor=1,
         status_forcelist=[500, 502, 503, 504],
-        # urllib3's default allowed_methods does NOT include POST, so the
-        # /transcribe upload would otherwise never be retried. POST retries
-        # are safe here because the server contract is idempotent on
-        # ``chunk_id`` (a re-sent body for the same chunk_id simply
-        # overwrites the previous one).
         allowed_methods=frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE", "POST"]),
     )
     adapter = HTTPAdapter(max_retries=retry_policy)
@@ -140,7 +98,7 @@ class TranscribeUploader:
     """
     POSTs accumulated audio buffers to the transcription server.
 
-    Body shape (do NOT change, server contract):
+    Body shape:
         { "audio_b64": str, "chunk_id": str, "tenant_id": str }
     """
 
@@ -178,22 +136,17 @@ class TranscribeUploader:
             print(f"Error sending chunk: {exc}")
 
 
-def _new_chunk_id() -> str:
-    """Return a fresh chunk_id (milliseconds since epoch)."""
+def _new_chunk_id() -> str: #Return a fresh chunk_id (milliseconds since epoch).
     return str(int(time.time() * 1000))
 
 
 def _register_session(server: str, source: str) -> str:
     """
-    Ask the server for a fresh tenant_id for this run.
+    Request a new tenant_id from the server.
 
-    Calls ``POST /session`` with ``{"source": <name>}``. The server mints
-    a uuid and records it as the latest session for that source, so curl
-    with ``?source=<name>`` will resolve to this run's transcripts.
-
-    Falls back to a locally-generated uuid if the server does not yet
-    implement ``/session`` (older builds), so the grabber still works,
-    just without the per-source ``?source=...`` resolution.
+    Calls POST /session with the source name and returns the generated
+    tenant_id. Falls back to a local UUID if the server does not support
+    the endpoint.
     """
     url = server.rstrip("/") + "/session"
     try:
@@ -217,29 +170,11 @@ def _register_session(server: str, source: str) -> str:
     return uuid.uuid4().hex
 
 
-# ---------------------------------------------------------------------------
-# Orchestration
-# ---------------------------------------------------------------------------
-
 def run(source: AudioSource, server: str, tenant_id: str) -> None:
     """
     Drive one of the ``AudioSource`` implementations: read PCM in
     ~1-second chunks, apply silence-based buffering, and upload each
     running buffer to ``/transcribe``.
-
-    Logic mirrors the original ``audio_grabber.py``:
-
-    - On silence : drop the working buffer and rotate ``chunk_id`` (the
-      buffer most recently sent under the old chunk_id is treated as that
-      chunk's final state on the server).
-    - On speech  : extend the buffer and POST the running buffer under the
-      current chunk_id. The server overwrites prior versions of the same
-      chunk_id with this newer (longer) audio.
-    - When the buffer reaches ``BUFFER_SIZE`` : the chunk just sent is
-      considered final; rotate ``chunk_id`` and start fresh.
-
-    ``stop()`` on the source is invoked in a ``finally`` block, so partial
-    starts and mid-stream interrupts are safe.
     """
     uploader = TranscribeUploader(server=server, tenant_id=tenant_id)
     buffer = bytearray()
@@ -249,8 +184,7 @@ def run(source: AudioSource, server: str, tenant_id: str) -> None:
         source.start()
         for pcm in source.read_chunk():
             if _is_silent(pcm):
-                # The buffer last sent is now the final state of this
-                # chunk on the server; reset locally and rotate.
+                # The buffer last sent is now the final state of this chunk on the server; reset locally and rotate.
                 buffer = bytearray()
                 chunk_id = _new_chunk_id()
                 continue
@@ -261,32 +195,23 @@ def run(source: AudioSource, server: str, tenant_id: str) -> None:
             if buffer:
                 uploader.send(bytes(buffer), chunk_id)
 
-            # If the buffer is full, the chunk we just sent is final;
-            # start a new one on the next non-silent input.
+            # If the buffer is full, the chunk we just sent is final; start a new one on the next non-silent input.
             if len(buffer) >= BUFFER_SIZE:
                 buffer = bytearray()
                 chunk_id = _new_chunk_id()
     except KeyboardInterrupt:
         print("\nInterrupted by user.")
     finally:
-        # Flush a final tail if a finite source ended mid-buffer, so the
-        # server has the complete final state of that chunk.
+        # Flush a final tail if a finite source ended mid-buffer, so the server has the complete final state of that chunk.
         if buffer:
             try:
                 uploader.send(bytes(buffer), chunk_id)
             except Exception as exc:
                 print(f"Error flushing final buffer: {exc}")
-        # ``stop()`` is required to be safe to call even if start() never
-        # completed; we call it unconditionally here.
         try:
             source.stop()
         except Exception as exc:
             print(f"Error stopping source: {exc}")
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -369,9 +294,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default="bestaudio/best",
         help="yt-dlp format selector (default: bestaudio/best).",
     )
-    # YouTube increasingly returns "Sign in to confirm you're not a bot"
-    # for data-center / VPN / WSL IPs. Pass cookies via one of these two
-    # mutually exclusive channels to authenticate.
+    # YouTube increasingly returns "Sign in to confirm you're not a bot" for data-center / VPN / WSL IPs. Pass cookies via one of these two mutually exclusive channels to authenticate.
     yt_auth = p_yt.add_mutually_exclusive_group()
     yt_auth.add_argument(
         "--cookies",
@@ -422,9 +345,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
     source = _build_source(args)
 
-    # Resolve the tenant_id for this run. If the user passed --tenant,
-    # honour it; otherwise ask the server to mint one and register it
-    # under this source name so `curl ...?source=<name>` will work.
+    # Resolve the tenant_id for this run. If the user passed --tenant, honour it; otherwise ask the server to mint one and register it under this source name so `curl ...?source=<name>` will work.
     if args.tenant:
         tenant_id = args.tenant
         registered = False

--- a/flask/audio_grabber.py
+++ b/flask/audio_grabber.py
@@ -1,8 +1,8 @@
 """
 SUSI Translator audio grabber (refactored orchestrator).
 
-Reads audio from one of four sources (microphone, file, URL, stdin),
-buffers up to ~10 seconds while resetting on silence, and POSTs
+Reads audio from one of five sources (microphone, file, URL, stdin,
+YouTube), buffers up to ~10 seconds while resetting on silence, and POSTs
 base64-encoded chunks to the transcription server's ``/transcribe``
 endpoint.
 
@@ -12,23 +12,25 @@ The POST body shape is unchanged from the original implementation::
 
 System requirements
 -------------------
-- ``mic``   : pyaudio (live capture).
-- ``file``  : pydub Python package + the ``ffmpeg`` binary on PATH.
-- ``url``   : the ``ffmpeg`` binary on PATH.
-- ``stdin`` : none beyond the standard library.
+- ``mic``     : pyaudio (live capture).
+- ``file``    : pydub Python package + the ``ffmpeg`` binary on PATH.
+- ``url``     : the ``ffmpeg`` binary on PATH.
+- ``stdin``   : none beyond the standard library.
+- ``youtube`` : the ``yt-dlp`` Python package + the ``ffmpeg`` binary on
+                PATH.
 
 Tenant IDs (auto-managed)
 -------------------------
 The grabber never asks the user for a tenant id. On startup it calls
 ``POST /session`` with the chosen subcommand (``mic``/``file``/``url``/
-``stdin``); the server mints a fresh tenant_id (uuid) and records it as
-the latest session for that source.
+``stdin``/``youtube``); the server mints a fresh tenant_id (uuid) and
+records it as the latest session for that source.
 
 To fetch transcripts, curl with ``?source=<name>`` instead of
 ``?tenant_id=...``::
 
     curl "http://localhost:5040/pop_first_transcript?source=mic"
-    curl "http://localhost:5040/pop_first_transcript?source=file"
+    curl "http://localhost:5040/pop_first_transcript?source=youtube"
 
 The server resolves ``source=mic`` to "the most recent mic session", so
 each fresh run gives you a clean bucket of transcripts under that fixed
@@ -42,6 +44,7 @@ Examples
     python audio_grabber.py mic --server http://localhost:5040
     python audio_grabber.py file --path talk.mp3 --realtime
     python audio_grabber.py url  --url https://example.com/stream.mp3
+    python audio_grabber.py youtube --url https://www.youtube.com/live/EXAMPLE_ID
     ffmpeg -i input.wav -f s16le -ac 1 -ar 16000 - | \\
         python audio_grabber.py stdin
 """
@@ -67,6 +70,7 @@ from audio_sources import (
     MicrophoneSource,
     StdinSource,
     URLSource,
+    YouTubeSource,
 )
 
 
@@ -77,7 +81,7 @@ BUFFER_SIZE: int = 2 * 10 * RATE  # bytes -> 10 seconds of audio
 SILENCE_THRESHOLD: int = 500
 
 DEFAULT_SERVER: str = "http://localhost:5040"
-VALID_SOURCES = ("mic", "file", "url", "stdin")
+VALID_SOURCES = ("mic", "file", "url", "stdin", "youtube")
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +293,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="audio_grabber",
         description=(
             "Capture audio from various sources (microphone, file, URL, "
-            "stdin) and stream it to the SUSI transcription server."
+            "stdin, YouTube) and stream it to the SUSI transcription server."
         ),
     )
     parser.add_argument(
@@ -309,7 +313,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(
         dest="source",
         required=True,
-        metavar="{mic,file,url,stdin}",
+        metavar="{mic,file,url,stdin,youtube}",
         help="Audio source to use.",
     )
 
@@ -351,6 +355,46 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Read raw 16 kHz / 16-bit / mono PCM from stdin.",
     )
 
+    p_yt = sub.add_parser(
+        "youtube",
+        help="Decode a YouTube (Live or VOD) URL via yt-dlp + ffmpeg.",
+    )
+    p_yt.add_argument(
+        "--url",
+        required=True,
+        help="YouTube watch / live URL.",
+    )
+    p_yt.add_argument(
+        "--format",
+        default="bestaudio/best",
+        help="yt-dlp format selector (default: bestaudio/best).",
+    )
+    # YouTube increasingly returns "Sign in to confirm you're not a bot"
+    # for data-center / VPN / WSL IPs. Pass cookies via one of these two
+    # mutually exclusive channels to authenticate.
+    yt_auth = p_yt.add_mutually_exclusive_group()
+    yt_auth.add_argument(
+        "--cookies",
+        dest="cookies_path",
+        default=None,
+        help=(
+            "Path to a Netscape-format cookies.txt file (export from your "
+            "browser via a 'Get cookies.txt' extension while logged into "
+            "YouTube). Bypasses YouTube's bot challenge."
+        ),
+    )
+    yt_auth.add_argument(
+        "--cookies-from-browser",
+        dest="cookies_from_browser",
+        default=None,
+        help=(
+            "Browser to read YouTube cookies from directly "
+            "(e.g. chrome, firefox, edge, brave). Note: on WSL this often "
+            "fails because the Windows browser's cookie store is outside "
+            "the WSL filesystem; prefer --cookies on WSL."
+        ),
+    )
+
     return parser
 
 
@@ -363,6 +407,13 @@ def _build_source(args: argparse.Namespace) -> AudioSource:
         return URLSource(url=args.url)
     if args.source == "stdin":
         return StdinSource()
+    if args.source == "youtube":
+        return YouTubeSource(
+            url=args.url,
+            format_selector=args.format,
+            cookies_path=args.cookies_path,
+            cookies_from_browser=args.cookies_from_browser,
+        )
     raise ValueError(f"Unknown source: {args.source}")
 
 

--- a/flask/audio_sources.py
+++ b/flask/audio_sources.py
@@ -8,23 +8,10 @@ implementations:
     - ``FileSource``       : decode a local audio file (pydub; requires ffmpeg).
     - ``URLSource``        : decode a remote HTTP(S) audio stream (ffmpeg).
     - ``StdinSource``      : read raw 16-bit / 16 kHz / mono PCM from stdin.
-    - ``YouTubeSource``    : decode a YouTube (Live or VOD) URL via yt-dlp +
-                             ffmpeg, with bounded auto-reconnect.
+    - ``YouTubeSource``    : decode a YouTube (Live or VOD) URL by piping
+                             ``yt-dlp``'s stdout straight into ``ffmpeg``.
 
 All sources MUST yield 16 kHz, 16-bit signed little-endian, mono PCM bytes.
-
-System requirements
--------------------
-- ``MicrophoneSource`` : PyAudio + a working input device.
-- ``FileSource``       : the ``pydub`` Python package and the ``ffmpeg``
-                         binary on PATH (pydub shells out to it for any
-                         non-WAV input).
-- ``URLSource``        : the ``ffmpeg`` binary on PATH.
-- ``StdinSource``      : none beyond the standard library. The caller is
-                         responsible for delivering audio in the required
-                         raw PCM format.
-- ``YouTubeSource``    : the ``yt-dlp`` Python package and the ``ffmpeg``
-                         binary on PATH.
 
 Each source's ``read_chunk()`` yields ~1 second of audio per iteration
 (``CHUNK_BYTES`` bytes) so the orchestrator can apply uniform silence
@@ -38,28 +25,16 @@ import sys
 import time
 import queue
 from abc import ABC, abstractmethod
-from typing import Generator, Optional
+from typing import Generator, List, Optional
 from urllib.parse import urlparse
 
-
-# Protocols ffmpeg is permitted to use when decoding a remote URL. Anything
-# outside this set (notably ``file``, ``concat``, ``pipe``, ``subfile`` and
-# friends) could be abused to read local resources, so it is rejected via
-# ffmpeg's ``-protocol_whitelist`` option.
 _ALLOWED_URL_SCHEMES: frozenset[str] = frozenset({"http", "https"})
 _FFMPEG_PROTOCOL_WHITELIST: str = "http,https,tcp,tls,crypto"
+# deliberately *not* including ``http``/``https`` means a malicious upstream can't trick ffmpeg into chasing arbitrary URLs.
+_FFMPEG_PROTOCOL_WHITELIST_PIPE: str = "pipe,crypto"
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def _read_up_to(stream, n: int) -> bytes:
-    """
-    Read up to ``n`` bytes from a binary stream, looping over short reads.
-
-    Returns fewer than ``n`` bytes only on EOF.
-    """
     buf = bytearray()
     while len(buf) < n:
         piece = stream.read(n - len(buf))
@@ -67,11 +42,6 @@ def _read_up_to(stream, n: int) -> bytes:
             break  # EOF
         buf.extend(piece)
     return bytes(buf)
-
-
-# ---------------------------------------------------------------------------
-# Abstract base class
-# ---------------------------------------------------------------------------
 
 class AudioSource(ABC):
     """
@@ -112,32 +82,18 @@ class AudioSource(ABC):
 
     @abstractmethod
     def stop(self) -> None:
-        """
-        Release the underlying resource.
-
-        MUST NOT raise even if ``start()`` was never called, and MUST be
-        safe to call multiple times.
-        """
+        """Stop / clean up the underlying resource. Safe to call multiple times."""
 
     @abstractmethod
     def read_chunk(self) -> Generator[bytes, None, None]:
-        """
-        Yield raw PCM frames in ~1-second chunks (``CHUNK_BYTES`` bytes
-        each, except possibly the last chunk for finite sources).
-        """
+        """Yield successive ~1-second chunks of PCM bytes until the source is exhausted or stop() is called."""
 
-    # Convenience context-manager support: ``with SomeSource(...) as src:``
     def __enter__(self) -> "AudioSource":
         self.start()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
         self.stop()
-
-
-# ---------------------------------------------------------------------------
-# MicrophoneSource
-# ---------------------------------------------------------------------------
 
 class MicrophoneSource(AudioSource):
     """
@@ -148,11 +104,7 @@ class MicrophoneSource(AudioSource):
     - PyAudio installed (``pip install pyaudio``).
     - A working input device.
 
-    Yields 1-second chunks of 16 kHz / 16-bit / mono PCM bytes. PyAudio is
-    callback-driven, so internally we push frames into a queue and
-    ``read_chunk()`` drains the queue. This decouples the audio thread from
-    the orchestrator and gives the same pull-style generator interface as
-    the other sources.
+    Yields 1-second chunks of 16 kHz / 16-bit / mono PCM bytes. 
     """
 
     def __init__(self, input_device_index: Optional[int] = None) -> None:
@@ -161,11 +113,10 @@ class MicrophoneSource(AudioSource):
         self._stream = None  # type: ignore[assignment]
         self._queue: "queue.Queue[bytes]" = queue.Queue()
         self._running: bool = False
-        self._pa_continue: int = 0  # set on start() to pyaudio.paContinue
+        self._pa_continue: int = 0 # will be set to pyaudio.paContinue in start()
 
     def start(self) -> None:
-        # Imported lazily so that other sources work even if PyAudio is
-        # unavailable on the host (e.g. headless server with no audio libs).
+        # Imported lazily so that other sources work even if PyAudio is unavailable on the host (e.g. headless server with no audio libs).
         import pyaudio
 
         self._pa_continue = pyaudio.paContinue
@@ -182,7 +133,7 @@ class MicrophoneSource(AudioSource):
         self._running = True
         self._stream.start_stream()
 
-    def _callback(self, in_data, frame_count, time_info, status):  # type: ignore[no-untyped-def]
+    def _callback(self, in_data, frame_count, time_info, status):  
         # PyAudio callback signature is fixed; we just enqueue and continue.
         if self._running and in_data:
             self._queue.put(in_data)
@@ -199,8 +150,6 @@ class MicrophoneSource(AudioSource):
                 yield chunk
 
     def stop(self) -> None:
-        # Idempotent and exception-safe: must not raise even if start() was
-        # never called.
         self._running = False
         stream = self._stream
         audio = self._audio
@@ -227,11 +176,6 @@ class MicrophoneSource(AudioSource):
         except queue.Empty:
             pass
 
-
-# ---------------------------------------------------------------------------
-# FileSource
-# ---------------------------------------------------------------------------
-
 class FileSource(AudioSource):
     """
     Read audio from a local file (any format pydub/ffmpeg can decode).
@@ -242,9 +186,8 @@ class FileSource(AudioSource):
     - The ``ffmpeg`` binary on PATH (pydub shells out to it for any
       format other than WAV).
 
-    The file is decoded once on ``start()``, downmixed to mono, resampled
-    to 16 kHz, and converted to 16-bit signed PCM in memory.
-    ``read_chunk()`` then yields 1-second slices of that PCM buffer.
+    The file is decoded on start() and stored in memory. read_chunk()
+    returns 1-second PCM slices.
 
     Args
     ----
@@ -288,14 +231,10 @@ class FileSource(AudioSource):
         self._running = False
 
     def stop(self) -> None:
-        # No external resources to release; just clear state.
         self._running = False
         self._pcm = b""
 
 
-# ---------------------------------------------------------------------------
-# URLSource
-# ---------------------------------------------------------------------------
 
 class URLSource(AudioSource):
     """
@@ -306,9 +245,9 @@ class URLSource(AudioSource):
     -------------------
     - The ``ffmpeg`` binary on PATH.
 
-    ``ffmpeg`` is invoked once on ``start()`` and produces a continuous
-    stream of 16 kHz / 16-bit / mono PCM on stdout. ``read_chunk()`` reads
-    1 second per iteration until ffmpeg exits or ``stop()`` is called.
+    On start(), ffmpeg converts the stream to 16 kHz, 16-bit mono PCM.
+    read_chunk() returns 1-second PCM chunks until the stream ends or
+    stop() is called.
     """
 
     def __init__(self, url: str) -> None:
@@ -319,20 +258,11 @@ class URLSource(AudioSource):
     @staticmethod
     def _validate_url(url: str) -> str:
         """
-        Enforce that ``url`` is a well-formed HTTP(S) URL before it is ever
-        handed to ffmpeg.
-
-        This is the first line of defence against the security audit
-        finding on the ``subprocess.Popen`` call below: by the time the
-        URL reaches ffmpeg we have already guaranteed it is not an option
-        flag (e.g. ``-something``) and not a non-network scheme such as
-        ``file://`` or ``concat:`` that could be used to read local
-        resources.
+        Validate that the URL is a safe HTTP/HTTPS network URL before passing it to ffmpeg.
         """
         if not isinstance(url, str) or not url:
             raise ValueError("URLSource: url must be a non-empty string")
         # Reject anything that could be parsed as an option flag by ffmpeg
-        # before the scheme check, just to be explicit.
         if url.startswith("-"):
             raise ValueError("URLSource: url must not start with '-'")
         parsed = urlparse(url)
@@ -346,12 +276,7 @@ class URLSource(AudioSource):
         return url
 
     def start(self) -> None:
-        # SECURITY: ``self._url`` has been validated by ``_validate_url`` to
-        # be an http(s) URL with a host and no leading ``-``. We invoke
-        # ffmpeg with a fixed argv list (``shell=False``) and additionally
-        # pass ``-protocol_whitelist`` so ffmpeg itself refuses any nested
-        # redirect to a non-network protocol. This addresses the static
-        # analysis warning about a non-static argument to ``subprocess.Popen``.
+        # SECURITY: self._url is validated, ffmpeg runs with shell=False and a protocol whitelist, preventing unsafe redirects and command injection.
         cmd = [
             "ffmpeg",
             "-loglevel", "error",
@@ -363,7 +288,7 @@ class URLSource(AudioSource):
             "-ar", str(self.SAMPLE_RATE),
             "-",  # write to stdout
         ]
-        self._proc = subprocess.Popen(  # noqa: S603  # validated argv, shell=False
+        self._proc = subprocess.Popen(  
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -401,25 +326,16 @@ class URLSource(AudioSource):
             except Exception:
                 pass
 
-
-# ---------------------------------------------------------------------------
-# StdinSource
-# ---------------------------------------------------------------------------
-
 class StdinSource(AudioSource):
     """
-    Read raw 16 kHz / 16-bit / mono PCM from standard input.
+    Read raw 16 kHz, 16-bit mono PCM audio from stdin.
 
-    Useful for piping arbitrary tools into the grabber, e.g.::
-
-        ffmpeg -i input.flac -f s16le -ac 1 -ar 16000 - | \\
+    Example:
+        ffmpeg -i input.flac -f s16le -ac 1 -ar 16000 - | \
             python audio_grabber.py stdin --server http://localhost:5040
 
-    System requirements
-    -------------------
-    None beyond the standard library. The caller is responsible for
-    delivering audio in the required raw PCM format; this source does no
-    decoding or resampling of its own.
+    The input must already be in the required PCM format; no decoding or
+    resampling is performed.
     """
 
     def __init__(self) -> None:
@@ -427,8 +343,7 @@ class StdinSource(AudioSource):
         self._stream = None  # type: ignore[assignment]
 
     def start(self) -> None:
-        # Use the underlying binary buffer to avoid newline translation
-        # on Windows.
+        # Use the underlying binary buffer to avoid newline translation on Windows.
         self._stream = sys.stdin.buffer
         self._running = True
 
@@ -444,53 +359,19 @@ class StdinSource(AudioSource):
         self._running = False
 
     def stop(self) -> None:
-        # We never own stdin; just clear state.
         self._running = False
         self._stream = None
 
-
-
-
-# ---------------------------------------------------------------------------
-# YouTubeSource
-# ---------------------------------------------------------------------------
-
 class YouTubeSource(AudioSource):
     """
-    Decode the audio of a YouTube (Live or VOD) URL by resolving it via
-    ``yt-dlp`` into a direct media URL, then piping that through ``ffmpeg``
-    to produce the same 16 kHz / 16-bit / mono PCM output as the other
-    sources.
+    Decode a YouTube (Live or VOD) URL into the standard 16 kHz / 16-bit /
+    mono PCM stream by chaining two subprocesses::
 
-    System requirements
-    -------------------
-    - The ``yt-dlp`` Python package (``pip install yt-dlp``).
-    - The ``ffmpeg`` binary on PATH.
+        yt-dlp -f <fmt> -o - <url>  |  ffmpeg -i pipe:0 ... -f s16le -
 
-    URL validation
-    --------------
-    URLs are validated in ``__init__`` *before* yt-dlp or ffmpeg are
-    invoked. The same defensive checks as ``URLSource`` apply (non-empty
-    string, no leading ``-``, http/https scheme, host present), plus a
-    YouTube-domain allow-list to refuse arbitrary http(s) URLs that just
-    happen to be valid. Bad input therefore never reaches a subprocess.
-
-    Reconnection
-    ------------
-    Live YouTube streams produce HLS manifests whose internal segment
-    URLs rotate periodically and can transiently fail. If the ffmpeg
-    subprocess exits before ``stop()`` was called, this source will
-    re-resolve the URL via yt-dlp and respawn ffmpeg, with capped
-    exponential backoff so a permanently-ended stream does not spin
-    forever. The reconnect counter is reset after the first successful
-    chunk is yielded post-respawn, so a long-running stream that drops
-    once an hour stays healthy indefinitely.
+    See the README for requirements (yt-dlp + ffmpeg on PATH) and cookie-based auth.
     """
 
-    # Exact-match allow-list. Suffix matching (``*.youtube.com``) is
-    # tempting but error-prone (``youtube.com.evil.example`` would slip
-    # through naive checks); we prefer an explicit list and let users
-    # extend it via PR if they hit a legitimate host that's missing.
     _ALLOWED_HOSTS: frozenset[str] = frozenset({
         "youtube.com",
         "www.youtube.com",
@@ -501,10 +382,6 @@ class YouTubeSource(AudioSource):
         "www.youtube-nocookie.com",
     })
 
-    _MAX_RECONNECTS: int = 5
-    _BACKOFF_BASE_SEC: float = 1.0
-    _BACKOFF_CAP_SEC: float = 16.0
-
     def __init__(
         self,
         url: str,
@@ -512,8 +389,7 @@ class YouTubeSource(AudioSource):
         cookies_path: Optional[str] = None,
         cookies_from_browser: Optional[str] = None,
     ) -> None:
-        # Mutually exclusive: yt-dlp would silently honour only one,
-        # which makes misconfiguration hard to debug.
+        # yt-dlp silently honours only one, so reject both up front.
         if cookies_path and cookies_from_browser:
             raise ValueError(
                 "YouTubeSource: pass at most one of cookies_path or "
@@ -523,21 +399,15 @@ class YouTubeSource(AudioSource):
         self._format_selector: str = format_selector
         self._cookies_path: Optional[str] = cookies_path
         self._cookies_from_browser: Optional[str] = cookies_from_browser
-        self._proc: Optional[subprocess.Popen] = None
+        self._ydl_proc: Optional[subprocess.Popen] = None
+        self._ffmpeg_proc: Optional[subprocess.Popen] = None
         self._running: bool = False
-        self._reconnects: int = 0
 
-    # -- Validation ---------------------------------------------------------
 
     @classmethod
     def _validate_url(cls, url: str) -> str:
-        """
-        Reject obviously bad input before any network call or subprocess.
-
-        Mirrors ``URLSource._validate_url`` (non-empty, no leading ``-``,
-        http/https scheme, host present) and additionally requires the
-        host to be a recognised YouTube domain.
-        """
+        """Reject bad input before any subprocess: must be an http(s) URL
+        with a recognised YouTube host and no leading ``-``."""
         if not isinstance(url, str) or not url:
             raise ValueError("YouTubeSource: url must be a non-empty string")
         if url.startswith("-"):
@@ -558,158 +428,103 @@ class YouTubeSource(AudioSource):
             )
         return url
 
-    # -- yt-dlp resolution + ffmpeg spawning -------------------------------
 
-    def _resolve_media_url(self) -> str:
-        """
-        Use yt-dlp to extract the direct media URL for the chosen format.
-
-        Imported lazily so callers that only need URL validation (e.g.
-        unit tests) do not require yt-dlp to be installed, matching the
-        lazy-import style of ``MicrophoneSource`` (PyAudio) and
-        ``FileSource`` (pydub).
-        """
-        from yt_dlp import YoutubeDL  # imported lazily
-
-        opts = {
-            "format": self._format_selector,
-            "quiet": True,
-            "no_warnings": True,
-            "noplaylist": True,
-            "skip_download": True,
-            # Enable both runtimes; yt-dlp picks whichever is on PATH
-            # (deno > node). Empty config dicts mean "auto-discover".
-            "js_runtimes": {"deno": {}, "node": {}},
-            # PyPI installs of yt-dlp don't bundle the EJS solver
-            # scripts; this lets yt-dlp fetch them from GitHub on demand
-            # so users don't need a separate yt-dlp-ejs install.
-            "remote_components": ["ejs:github"],
-        }
-        # YouTube anti-bot bypass via cookies (mutex enforced in __init__).
+    def _build_ydl_argv(self) -> List[str]:
+        # ``--`` before the URL ensures it can never be parsed as a flag.
+        argv: List[str] = [
+            "yt-dlp",
+            "--quiet",
+            "--no-warnings",
+            "--no-playlist",
+            "--no-progress",
+            "-f", self._format_selector,
+            "-o", "-",
+        ]
         if self._cookies_path:
-            opts["cookiefile"] = self._cookies_path
+            argv += ["--cookies", self._cookies_path]
         elif self._cookies_from_browser:
-            # yt-dlp expects a tuple (browser, [profile, keyring, container]).
-            opts["cookiesfrombrowser"] = (self._cookies_from_browser,)
-        with YoutubeDL(opts) as ydl:
-            info = ydl.extract_info(self._watch_url, download=False)
+            argv += ["--cookies-from-browser", self._cookies_from_browser]
+        argv += ["--", self._watch_url]
+        return argv
 
-        media_url = info.get("url")
-        if not media_url:
-            # Some format selectors return a list of merged formats
-            # rather than a flat 'url'. Pick the first audio-bearing one.
-            for f in info.get("requested_formats") or []:
-                if f.get("url"):
-                    media_url = f["url"]
-                    break
-        if not media_url:
-            raise RuntimeError(
-                f"YouTubeSource: yt-dlp could not resolve a media URL for "
-                f"{self._watch_url!r} with format {self._format_selector!r}"
-            )
-        return media_url
-
-    def _spawn_ffmpeg(self, media_url: str) -> None:
-        """
-        Spawn ffmpeg with the resolved direct media URL. Same fixed argv
-        and ``-protocol_whitelist`` as ``URLSource``, so ffmpeg itself
-        refuses any nested redirect to a non-network protocol.
-        """
-        cmd = [
+    def _build_ffmpeg_argv(self) -> List[str]:
+        return [
             "ffmpeg",
             "-loglevel", "error",
-            "-protocol_whitelist", _FFMPEG_PROTOCOL_WHITELIST,
-            "-i", media_url,
+            "-protocol_whitelist", _FFMPEG_PROTOCOL_WHITELIST_PIPE,
+            "-i", "pipe:0",
             "-f", "s16le",
             "-acodec", "pcm_s16le",
             "-ac", str(self.CHANNELS),
             "-ar", str(self.SAMPLE_RATE),
-            "-",  # write to stdout
+            "-",
         ]
-        self._proc = subprocess.Popen(  # noqa: S603  # validated argv, shell=False
-            cmd,
+
+
+    def start(self) -> None:
+        # SECURITY: validated URL + fixed argv + shell=False; ffmpeg's input is a local pipe, hence the pipe-only protocol whitelist.
+        ydl_argv = self._build_ydl_argv()
+        ff_argv = self._build_ffmpeg_argv()
+
+        self._ydl_proc = subprocess.Popen( 
+            ydl_argv,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=None,  # inherit: errors print to console
             shell=False,
         )
 
-    def _terminate_proc(self) -> None:
-        """Idempotent ffmpeg teardown; never raises."""
-        proc = self._proc
-        self._proc = None
-        if proc is None:
-            return
         try:
-            proc.terminate()
+            self._ffmpeg_proc = subprocess.Popen(  
+                ff_argv,
+                stdin=self._ydl_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                shell=False,
+            )
         except Exception:
-            pass
-        try:
-            proc.wait(timeout=2.0)
-        except Exception:
+            # Don't leave yt-dlp orphaned if ffmpeg fails to spawn.
+            self._terminate_procs()
+            raise
+
+        if self._ydl_proc.stdout is not None:
             try:
-                proc.kill()
+                self._ydl_proc.stdout.close()
             except Exception:
                 pass
 
-    def _try_reconnect(self) -> bool:
-        """
-        Tear down the current ffmpeg and try to bring up a fresh one.
-
-        Loops over up to ``_MAX_RECONNECTS`` attempts with exponential
-        backoff so a transient yt-dlp / ffmpeg failure is not terminal.
-        Returns True if a fresh ffmpeg is running, False if all retries
-        have been exhausted (caller should let the source end).
-        """
-        while self._reconnects < self._MAX_RECONNECTS and self._running:
-            self._reconnects += 1
-            backoff = min(
-                self._BACKOFF_BASE_SEC * (2 ** (self._reconnects - 1)),
-                self._BACKOFF_CAP_SEC,
-            )
-            self._terminate_proc()
-            time.sleep(backoff)
-            try:
-                media_url = self._resolve_media_url()
-                self._spawn_ffmpeg(media_url)
-                return True
-            except Exception:
-                # Resolution / spawn failed; loop and try again until we
-                # hit the cap. Any leftover proc state is cleaned up.
-                self._terminate_proc()
-                continue
-        return False
-
-    # -- AudioSource lifecycle ---------------------------------------------
-
-    def start(self) -> None:
-        media_url = self._resolve_media_url()
-        self._spawn_ffmpeg(media_url)
         self._running = True
-        self._reconnects = 0
 
     def read_chunk(self) -> Generator[bytes, None, None]:
         chunk_bytes: int = self.CHUNK_BYTES
         while self._running:
-            proc = self._proc
+            proc = self._ffmpeg_proc
             if proc is None or proc.stdout is None:
                 break
             buf = _read_up_to(proc.stdout, chunk_bytes)
-            if buf:
-                # First successful chunk after a respawn resets the
-                # reconnect counter so a long-running stream that drops
-                # occasionally stays healthy.
-                if self._reconnects:
-                    self._reconnects = 0
-                yield buf
-                continue
-            # ffmpeg ended. If stop() was called, exit cleanly.
-            if not self._running:
+            if not buf:
                 break
-            # Otherwise this is a stream interruption; try to recover.
-            if not self._try_reconnect():
-                break
+            yield buf
         self._running = False
+
+    def _terminate_procs(self) -> None:
+        for attr in ("_ffmpeg_proc", "_ydl_proc"):
+            proc: Optional[subprocess.Popen] = getattr(self, attr, None)
+            setattr(self, attr, None)
+            if proc is None:
+                continue
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=2.0)
+            except Exception:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
 
     def stop(self) -> None:
         self._running = False
-        self._terminate_proc()
+        self._terminate_procs()

--- a/flask/audio_sources.py
+++ b/flask/audio_sources.py
@@ -288,7 +288,10 @@ class URLSource(AudioSource):
             "-ar", str(self.SAMPLE_RATE),
             "-",  # write to stdout
         ]
-        self._proc = subprocess.Popen(  
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+        # Safe: self._url is validated by _validate_url() (scheme whitelist,
+        # no leading '-', host required); argv is a fixed list with shell=False.
+        self._proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -466,7 +469,11 @@ class YouTubeSource(AudioSource):
         ydl_argv = self._build_ydl_argv()
         ff_argv = self._build_ffmpeg_argv()
 
-        self._ydl_proc = subprocess.Popen( 
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+        # Safe: URL validated by _validate_url() (YouTube host whitelist, no
+        # leading '-'); argv built from fixed flags with '--' before the URL,
+        # shell=False.
+        self._ydl_proc = subprocess.Popen(
             ydl_argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -475,7 +482,10 @@ class YouTubeSource(AudioSource):
         )
 
         try:
-            self._ffmpeg_proc = subprocess.Popen(  
+            # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+            # Safe: fixed argv, input is the local yt-dlp pipe, pipe-only
+            # protocol whitelist, shell=False.
+            self._ffmpeg_proc = subprocess.Popen(
                 ff_argv,
                 stdin=self._ydl_proc.stdout,
                 stdout=subprocess.PIPE,

--- a/flask/audio_sources.py
+++ b/flask/audio_sources.py
@@ -1,13 +1,15 @@
 """
 Audio source abstractions for the SUSI Translator audio grabber.
 
-This module defines an ``AudioSource`` abstract base class plus four concrete
+This module defines an ``AudioSource`` abstract base class plus five concrete
 implementations:
 
     - ``MicrophoneSource`` : live capture from a system microphone (PyAudio).
     - ``FileSource``       : decode a local audio file (pydub; requires ffmpeg).
     - ``URLSource``        : decode a remote HTTP(S) audio stream (ffmpeg).
     - ``StdinSource``      : read raw 16-bit / 16 kHz / mono PCM from stdin.
+    - ``YouTubeSource``    : decode a YouTube (Live or VOD) URL via yt-dlp +
+                             ffmpeg, with bounded auto-reconnect.
 
 All sources MUST yield 16 kHz, 16-bit signed little-endian, mono PCM bytes.
 
@@ -21,6 +23,8 @@ System requirements
 - ``StdinSource``      : none beyond the standard library. The caller is
                          responsible for delivering audio in the required
                          raw PCM format.
+- ``YouTubeSource``    : the ``yt-dlp`` Python package and the ``ffmpeg``
+                         binary on PATH.
 
 Each source's ``read_chunk()`` yields ~1 second of audio per iteration
 (``CHUNK_BYTES`` bytes) so the orchestrator can apply uniform silence
@@ -443,3 +447,269 @@ class StdinSource(AudioSource):
         # We never own stdin; just clear state.
         self._running = False
         self._stream = None
+
+
+
+
+# ---------------------------------------------------------------------------
+# YouTubeSource
+# ---------------------------------------------------------------------------
+
+class YouTubeSource(AudioSource):
+    """
+    Decode the audio of a YouTube (Live or VOD) URL by resolving it via
+    ``yt-dlp`` into a direct media URL, then piping that through ``ffmpeg``
+    to produce the same 16 kHz / 16-bit / mono PCM output as the other
+    sources.
+
+    System requirements
+    -------------------
+    - The ``yt-dlp`` Python package (``pip install yt-dlp``).
+    - The ``ffmpeg`` binary on PATH.
+
+    URL validation
+    --------------
+    URLs are validated in ``__init__`` *before* yt-dlp or ffmpeg are
+    invoked. The same defensive checks as ``URLSource`` apply (non-empty
+    string, no leading ``-``, http/https scheme, host present), plus a
+    YouTube-domain allow-list to refuse arbitrary http(s) URLs that just
+    happen to be valid. Bad input therefore never reaches a subprocess.
+
+    Reconnection
+    ------------
+    Live YouTube streams produce HLS manifests whose internal segment
+    URLs rotate periodically and can transiently fail. If the ffmpeg
+    subprocess exits before ``stop()`` was called, this source will
+    re-resolve the URL via yt-dlp and respawn ffmpeg, with capped
+    exponential backoff so a permanently-ended stream does not spin
+    forever. The reconnect counter is reset after the first successful
+    chunk is yielded post-respawn, so a long-running stream that drops
+    once an hour stays healthy indefinitely.
+    """
+
+    # Exact-match allow-list. Suffix matching (``*.youtube.com``) is
+    # tempting but error-prone (``youtube.com.evil.example`` would slip
+    # through naive checks); we prefer an explicit list and let users
+    # extend it via PR if they hit a legitimate host that's missing.
+    _ALLOWED_HOSTS: frozenset[str] = frozenset({
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+        "youtu.be",
+        "youtube-nocookie.com",
+        "www.youtube-nocookie.com",
+    })
+
+    _MAX_RECONNECTS: int = 5
+    _BACKOFF_BASE_SEC: float = 1.0
+    _BACKOFF_CAP_SEC: float = 16.0
+
+    def __init__(
+        self,
+        url: str,
+        format_selector: str = "bestaudio/best",
+        cookies_path: Optional[str] = None,
+        cookies_from_browser: Optional[str] = None,
+    ) -> None:
+        # Mutually exclusive: yt-dlp would silently honour only one,
+        # which makes misconfiguration hard to debug.
+        if cookies_path and cookies_from_browser:
+            raise ValueError(
+                "YouTubeSource: pass at most one of cookies_path or "
+                "cookies_from_browser, not both"
+            )
+        self._watch_url: str = self._validate_url(url)
+        self._format_selector: str = format_selector
+        self._cookies_path: Optional[str] = cookies_path
+        self._cookies_from_browser: Optional[str] = cookies_from_browser
+        self._proc: Optional[subprocess.Popen] = None
+        self._running: bool = False
+        self._reconnects: int = 0
+
+    # -- Validation ---------------------------------------------------------
+
+    @classmethod
+    def _validate_url(cls, url: str) -> str:
+        """
+        Reject obviously bad input before any network call or subprocess.
+
+        Mirrors ``URLSource._validate_url`` (non-empty, no leading ``-``,
+        http/https scheme, host present) and additionally requires the
+        host to be a recognised YouTube domain.
+        """
+        if not isinstance(url, str) or not url:
+            raise ValueError("YouTubeSource: url must be a non-empty string")
+        if url.startswith("-"):
+            raise ValueError("YouTubeSource: url must not start with '-'")
+        parsed = urlparse(url)
+        if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES:
+            raise ValueError(
+                f"YouTubeSource: unsupported URL scheme {parsed.scheme!r}; "
+                f"allowed schemes are {sorted(_ALLOWED_URL_SCHEMES)}"
+            )
+        if not parsed.netloc:
+            raise ValueError("YouTubeSource: url must include a host")
+        host = (parsed.hostname or "").lower()
+        if host not in cls._ALLOWED_HOSTS:
+            raise ValueError(
+                f"YouTubeSource: host {host!r} is not a recognised YouTube "
+                f"domain. Allowed hosts: {sorted(cls._ALLOWED_HOSTS)}"
+            )
+        return url
+
+    # -- yt-dlp resolution + ffmpeg spawning -------------------------------
+
+    def _resolve_media_url(self) -> str:
+        """
+        Use yt-dlp to extract the direct media URL for the chosen format.
+
+        Imported lazily so callers that only need URL validation (e.g.
+        unit tests) do not require yt-dlp to be installed, matching the
+        lazy-import style of ``MicrophoneSource`` (PyAudio) and
+        ``FileSource`` (pydub).
+        """
+        from yt_dlp import YoutubeDL  # imported lazily
+
+        opts = {
+            "format": self._format_selector,
+            "quiet": True,
+            "no_warnings": True,
+            "noplaylist": True,
+            "skip_download": True,
+            # Enable both runtimes; yt-dlp picks whichever is on PATH
+            # (deno > node). Empty config dicts mean "auto-discover".
+            "js_runtimes": {"deno": {}, "node": {}},
+            # PyPI installs of yt-dlp don't bundle the EJS solver
+            # scripts; this lets yt-dlp fetch them from GitHub on demand
+            # so users don't need a separate yt-dlp-ejs install.
+            "remote_components": ["ejs:github"],
+        }
+        # YouTube anti-bot bypass via cookies (mutex enforced in __init__).
+        if self._cookies_path:
+            opts["cookiefile"] = self._cookies_path
+        elif self._cookies_from_browser:
+            # yt-dlp expects a tuple (browser, [profile, keyring, container]).
+            opts["cookiesfrombrowser"] = (self._cookies_from_browser,)
+        with YoutubeDL(opts) as ydl:
+            info = ydl.extract_info(self._watch_url, download=False)
+
+        media_url = info.get("url")
+        if not media_url:
+            # Some format selectors return a list of merged formats
+            # rather than a flat 'url'. Pick the first audio-bearing one.
+            for f in info.get("requested_formats") or []:
+                if f.get("url"):
+                    media_url = f["url"]
+                    break
+        if not media_url:
+            raise RuntimeError(
+                f"YouTubeSource: yt-dlp could not resolve a media URL for "
+                f"{self._watch_url!r} with format {self._format_selector!r}"
+            )
+        return media_url
+
+    def _spawn_ffmpeg(self, media_url: str) -> None:
+        """
+        Spawn ffmpeg with the resolved direct media URL. Same fixed argv
+        and ``-protocol_whitelist`` as ``URLSource``, so ffmpeg itself
+        refuses any nested redirect to a non-network protocol.
+        """
+        cmd = [
+            "ffmpeg",
+            "-loglevel", "error",
+            "-protocol_whitelist", _FFMPEG_PROTOCOL_WHITELIST,
+            "-i", media_url,
+            "-f", "s16le",
+            "-acodec", "pcm_s16le",
+            "-ac", str(self.CHANNELS),
+            "-ar", str(self.SAMPLE_RATE),
+            "-",  # write to stdout
+        ]
+        self._proc = subprocess.Popen(  # noqa: S603  # validated argv, shell=False
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            shell=False,
+        )
+
+    def _terminate_proc(self) -> None:
+        """Idempotent ffmpeg teardown; never raises."""
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=2.0)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _try_reconnect(self) -> bool:
+        """
+        Tear down the current ffmpeg and try to bring up a fresh one.
+
+        Loops over up to ``_MAX_RECONNECTS`` attempts with exponential
+        backoff so a transient yt-dlp / ffmpeg failure is not terminal.
+        Returns True if a fresh ffmpeg is running, False if all retries
+        have been exhausted (caller should let the source end).
+        """
+        while self._reconnects < self._MAX_RECONNECTS and self._running:
+            self._reconnects += 1
+            backoff = min(
+                self._BACKOFF_BASE_SEC * (2 ** (self._reconnects - 1)),
+                self._BACKOFF_CAP_SEC,
+            )
+            self._terminate_proc()
+            time.sleep(backoff)
+            try:
+                media_url = self._resolve_media_url()
+                self._spawn_ffmpeg(media_url)
+                return True
+            except Exception:
+                # Resolution / spawn failed; loop and try again until we
+                # hit the cap. Any leftover proc state is cleaned up.
+                self._terminate_proc()
+                continue
+        return False
+
+    # -- AudioSource lifecycle ---------------------------------------------
+
+    def start(self) -> None:
+        media_url = self._resolve_media_url()
+        self._spawn_ffmpeg(media_url)
+        self._running = True
+        self._reconnects = 0
+
+    def read_chunk(self) -> Generator[bytes, None, None]:
+        chunk_bytes: int = self.CHUNK_BYTES
+        while self._running:
+            proc = self._proc
+            if proc is None or proc.stdout is None:
+                break
+            buf = _read_up_to(proc.stdout, chunk_bytes)
+            if buf:
+                # First successful chunk after a respawn resets the
+                # reconnect counter so a long-running stream that drops
+                # occasionally stays healthy.
+                if self._reconnects:
+                    self._reconnects = 0
+                yield buf
+                continue
+            # ffmpeg ended. If stop() was called, exit cleanly.
+            if not self._running:
+                break
+            # Otherwise this is a stream interruption; try to recover.
+            if not self._try_reconnect():
+                break
+        self._running = False
+
+    def stop(self) -> None:
+        self._running = False
+        self._terminate_proc()

--- a/flask/tests/test_youtube_source_security.py
+++ b/flask/tests/test_youtube_source_security.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from audio_sources import YouTubeSource
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://music.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://youtu.be/dQw4w9WgXcQ",
+        "https://www.youtube.com/live/EXAMPLE_ID",
+        "https://www.youtube-nocookie.com/embed/EXAMPLE_ID",
+        # http (not https) is permitted at validation time; ffmpeg's
+        # -protocol_whitelist still constrains what it will follow.
+        "http://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    ],
+)
+def test_valid_youtube_urls_are_accepted(url):
+    src = YouTubeSource(url)
+    assert src._watch_url == url
+
+
+@pytest.mark.parametrize(
+    "bad_url, reason_substring",
+    [
+        ("", "non-empty"),
+        ("file:///etc/passwd", "unsupported URL scheme"),
+        ("concat:foo|bar", "unsupported URL scheme"),
+        ("pipe:0", "unsupported URL scheme"),
+        ("ftp://www.youtube.com/foo", "unsupported URL scheme"),
+        ("-i evil", "must not start with '-'"),
+        ("http://", "host"),
+        # Non-YouTube hosts must be rejected even when otherwise valid.
+        ("https://evil.example/watch?v=x", "not a recognised YouTube domain"),
+        ("https://notyoutube.com/watch?v=x", "not a recognised YouTube domain"),
+        # Look-alike host: youtube.com appears as a subdomain of an
+        # attacker-controlled root. Exact-match allow-list rejects this.
+        ("https://youtube.com.evil.example/watch?v=x", "not a recognised YouTube domain"),
+    ],
+)
+def test_invalid_youtube_urls_are_rejected(bad_url, reason_substring):
+    with pytest.raises(ValueError) as exc_info:
+        YouTubeSource(bad_url)
+    assert reason_substring in str(exc_info.value)
+
+
+def test_non_string_input_is_rejected():
+    with pytest.raises(ValueError):
+        YouTubeSource(None)  # type: ignore[arg-type]
+
+
+def test_validator_rejects_before_yt_dlp_or_ffmpeg_is_invoked():
+    # Validator must run in __init__, not lazily in start(), so neither
+    # yt-dlp nor ffmpeg are reached for bad input. (Asserted indirectly:
+    # constructing the bad source raises before any side effect.)
+    with pytest.raises(ValueError):
+        YouTubeSource("https://evil.example/")
+
+
+def test_cookies_options_are_mutually_exclusive():
+    # Passing both cookies_path and cookies_from_browser is a caller
+    # error: yt-dlp would silently honour only one, making misconfig
+    # hard to debug. We surface it as ValueError at construct time.
+    with pytest.raises(ValueError, match="at most one of"):
+        YouTubeSource(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            cookies_path="/tmp/cookies.txt",
+            cookies_from_browser="chrome",
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cookies_path": "/tmp/cookies.txt"},
+        {"cookies_from_browser": "chrome"},
+        {},  # neither — current default, must still work
+    ],
+)
+def test_cookies_either_or_neither_is_accepted(kwargs):
+    # Each of the three valid configurations must construct without raising
+    # (the file path is not validated in __init__; yt-dlp will raise at
+    # start() time if it can't be read, matching FileSource's deferred
+    # validation pattern).
+    src = YouTubeSource("https://www.youtube.com/watch?v=dQw4w9WgXcQ", **kwargs)
+    assert src._cookies_path == kwargs.get("cookies_path")
+    assert src._cookies_from_browser == kwargs.get("cookies_from_browser")

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -15,21 +15,11 @@ import io
 import os
 from dotenv import load_dotenv
 
-# torch and whisper are imported lazily below — only when we actually need
-# to load local models. This keeps the module importable in environments
-# (and test runs) that delegate to a remote whisper.cpp server, where those
-# heavy deps are not installed.
 
-# Load environment variables from .env file
 load_dotenv()
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Helpers for env-var parsing
-# ---------------------------------------------------------------------------
 
 def _env_bool(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
@@ -41,11 +31,6 @@ def _env_bool(name: str, default: bool = False) -> bool:
 def _env_csv(name: str, default: str) -> list:
     raw = os.getenv(name, default)
     return [item.strip() for item in raw.split(",") if item.strip()]
-
-
-# ---------------------------------------------------------------------------
-# Flask + CORS configuration (env-driven)
-# ---------------------------------------------------------------------------
 
 app = Flask(__name__)
 api = Api(app, version='1.0', title='Transcription API',
@@ -60,28 +45,12 @@ _cors_origins = _env_csv(
 CORS(app, resources={r"/*": {"origins": _cors_origins}})
 logger.info(f"CORS allowed origins: {_cors_origins}")
 
-
-# ---------------------------------------------------------------------------
-# Whisper backend configuration
-# ---------------------------------------------------------------------------
-
 # We either use a local in-code model or access a whisper.cpp server.
 use_whisper_server = _env_bool('WHISPER_SERVER_USE', False)
-
-# Two distinct env vars so a power user can pick a fast model for high load
-# and a smart model for low load without collapsing them onto one variable.
-# Backwards compat: if the legacy single WHISPER_MODEL is set, it is used as
-# the default for both unless the more specific variables are also set.
 _legacy_model = os.getenv('WHISPER_MODEL')
 model_fast_name = os.getenv('WHISPER_MODEL_FAST', _legacy_model or 'small')    # 244M
 model_smart_name = os.getenv('WHISPER_MODEL_SMART', _legacy_model or 'medium')  # 769M
-
-# Detect hardware compatibility. We only need torch when loading local
-# models, so device detection is deferred to the lazy-import branch below.
 device = None
-
-# Whisper.cpp server URL. We expose the BASE URL in env (no path), and append
-# the endpoint path (e.g. /inference) at call time.
 whisper_server = os.getenv('WHISPER_SERVER', 'http://localhost:8007').rstrip('/')
 
 # Models are only loaded when we are NOT using the whisper.cpp server.
@@ -91,18 +60,13 @@ model_smart = None
 if use_whisper_server:
     logger.info(f"Whisper backend: server at {whisper_server}/inference")
 else:
-    # Lazy imports: torch and whisper are heavyweight optional deps. Only
-    # import them when we actually need to load a local model.
-    import torch  # noqa: WPS433  (deferred import is intentional)
-    import whisper  # noqa: WPS433  (deferred import is intentional)
+    import torch 
+    import whisper  
 
     print("TORCH CUDA:", torch.cuda.is_available())
     print("DEVICE COUNT:", torch.cuda.device_count())
     logger.info(f"Hardware detection: using {device}")
 
-    # Download (or load) two whisper models. If the download via the whisper
-    # library is not possible (offline / firewalled), prefer locally stored
-    # models from <script_dir>/models/<name>.pt.
     script_dir = os.path.dirname(os.path.abspath(__file__))
     models_path = os.path.join(script_dir, 'models')
 
@@ -116,41 +80,19 @@ else:
     model_fast = _load_whisper_model(model_fast_name)
     model_smart = _load_whisper_model(model_smart_name)
 
-
-# ---------------------------------------------------------------------------
-# Shared in-memory state
-# ---------------------------------------------------------------------------
-
 # transcripts:  tenant_id -> { chunk_id -> {'transcript': str} }
 transcriptd = {}
-# Single shared lock guarding ALL reads and writes to transcriptd. Must NEVER
-# be `threading.Lock()` re-instantiated inline (that pattern provides no
-# mutual exclusion at all).
 transcripts_lock = threading.Lock()
 
 # FIFO queue of pending audio chunks awaiting transcription.
 audio_stack = queue.Queue()
-
-# Per-source "latest session" registry.
-# Each grabber run calls POST /session?source=<mic|file|url|stdin|youtube> at startup;
-# the server mints a fresh tenant_id (uuid) and remembers it as the latest
-# tenant_id for that source along with a creation timestamp. Read endpoints
-# accept ?source=<name> as a convenience that resolves to the latest active
-# tenant_id for that source, so the user never has to type or remember the
-# uuid in curl commands. Stale sessions (older than SESSION_TTL_SECONDS)
-# are evicted on resolve.
 VALID_SOURCES = {"mic", "file", "url", "stdin", "youtube"}
 latest_session_by_source = {s: None for s in VALID_SOURCES}  # source -> (tenant_id, created_ts) or None
 session_lock = threading.Lock()
-
-# How long a per-source "latest session" pointer remains valid without
-# anyone refreshing it. Two hours by default; matches the transcript TTL.
 SESSION_TTL_SECONDS = int(os.getenv('SESSION_TTL_SECONDS', '7200'))
 
 
-# ---------------------------------------------------------------------------
 # Small helpers
-# ---------------------------------------------------------------------------
 
 def _parse_int_arg(args, name: str, default: int = None, required: bool = False) -> int:
     """
@@ -175,11 +117,6 @@ def _chunk_id_int(k):
     Best-effort int() of a chunk_id. Returns ``None`` for keys that cannot
     be interpreted as integers, so callers can defensively skip them
     rather than crashing the endpoint with a 500.
-
-    The worker only ever stores numeric millisecond timestamps as
-    chunk_ids, but the public ``POST /transcribe`` API does not validate
-    that constraint; a misbehaving client can still slip a non-numeric
-    id into ``transcriptd``.
     """
     try:
         return int(k)
@@ -221,11 +158,6 @@ def _resolve_tenant(args, default='0000'):
          source with no active session returns None so the caller can
          short-circuit with an empty response.
       3. Fall back to ``default`` (legacy behaviour).
-
-    Note: a None return for a known source is intentionally
-    indistinguishable from "session expired"; both result in an empty
-    transcript response. If you need a hard 404 for "no session yet",
-    add a separate endpoint rather than overloading this resolver.
     """
     explicit = args.get('tenant_id')
     if explicit:
@@ -280,26 +212,11 @@ def _whisper_server_transcribe(audio_int16: np.ndarray) -> dict:
     response.raise_for_status()
     return response.json()
 
-
-# ---------------------------------------------------------------------------
-# Audio worker
-# ---------------------------------------------------------------------------
-
 def _next_payload():
     """
     Pull the next audio payload from ``audio_stack``, dropping any superseded
     duplicates so we only transcribe the latest version of each
     (tenant_id, chunk_id).
-
-    Concurrency / accounting:
-      - For every entry returned from this function the caller MUST eventually
-        call ``audio_stack.task_done()`` exactly once (typically in a finally
-        block). Entries that this function discards because a newer one is
-        already queued are marked ``task_done()`` here so the queue's
-        unfinished_tasks counter stays correct (``audio_stack.join()`` works).
-      - The internal ``audio_stack.queue`` deque is scanned under
-        ``audio_stack.mutex`` so concurrent ``put``/``get`` cannot mutate it
-        while we iterate.
     """
     tenant_id, chunk_id, audiob64 = audio_stack.get()
     while True:
@@ -321,7 +238,6 @@ def process_audio():
         tenant_id, chunk_id, audiob64 = _next_payload()
         logger.debug(f"Queue length: {audio_stack.qsize()}")
         try:
-            # --- Decode + sanity-check the incoming audio ------------------
             audio_data = base64.b64decode(audiob64)
             audio_int16 = np.frombuffer(audio_data, dtype=np.int16)
 
@@ -334,7 +250,6 @@ def process_audio():
                 logger.warning(f"NaN values in audio array for chunk_id {chunk_id}")
                 continue
 
-            # --- Run transcription via the configured backend --------------
             qsize = audio_stack.qsize()
             if use_whisper_server:
                 # Whisper.cpp server doesn't expose a fast/smart distinction;
@@ -348,14 +263,13 @@ def process_audio():
             else:
                 # Local-model branch: torch was already imported at module
                 # load time when use_whisper_server=False, so this is cheap.
-                import torch  # noqa: WPS433  (already imported above)
+                import torch 
                 model = model_fast if qsize > 20 else model_smart
                 audio_tensor = torch.from_numpy(audio_float32)
                 result = model.transcribe(audio_tensor, temperature=0)
 
             transcript = (result.get('text') or '').strip()
 
-            # --- Validate + store ----------------------------------------
             if is_valid(transcript):
                 logger.info(f"VALID transcript for chunk_id {chunk_id}: {transcript}")
                 with transcripts_lock:
@@ -366,10 +280,7 @@ def process_audio():
 
                     current_transcript = transcripts.get(chunk_id)
                     if current_transcript:
-                        # Same chunk_id already exists: this audio is the
-                        # client's appended/extended version of the prior
-                        # buffer for the same chunk, so overwrite rather
-                        # than concatenate.
+                        # buffer for the same chunk, so overwrite rather than concatenate.
                         current_transcript['transcript'] = transcript
                     else:
                         transcripts[chunk_id] = {'transcript': transcript}
@@ -405,9 +316,6 @@ def is_valid(transcript):
 
 
 # Clean old transcripts: remove all chunks older than two hours and any tenants
-# that become empty as a result. Concurrency-safe: takes the shared
-# transcripts_lock and iterates over a snapshot so concurrent mutation in
-# process_audio cannot raise "dictionary changed size during iteration".
 def clean_old_transcripts():
     current_time_ms = int(time.time() * 1000)
     two_hours_ago_ms = current_time_ms - (2 * 60 * 60 * 1000)
@@ -421,9 +329,7 @@ def clean_old_transcripts():
                 empty_tenants.append(tenant_id)
                 continue
 
-            # Snapshot chunk ids; some chunk_ids may be non-numeric in
-            # principle, so we defensively skip those rather than crashing
-            # the worker thread.
+            # Snapshot chunk ids; some chunk_ids may be non-numeric in principle, so we defensively skip those rather than crashing the worker thread.
             stale_chunks = []
             for chunk_id in list(transcripts.keys()):
                 try:
@@ -442,8 +348,6 @@ def clean_old_transcripts():
         for tenant_id in empty_tenants:
             transcriptd.pop(tenant_id, None)
 
-
-# merge all transcripts into one and split them into sentences
 def merge_and_split_transcripts(transcripts):
     """
     Take a ``{chunk_id: {'transcript': str}}`` mapping and produce a new
@@ -455,10 +359,6 @@ def merge_and_split_transcripts(transcripts):
     last chunk for any trailing fragment). Values are dicts with a
     ``'transcript'`` key so callers can use the same access pattern as
     the underlying ``transcriptd`` store.
-
-    The previous implementation called ``.strip()`` directly on values,
-    which crashed at runtime because values are dicts, not strings; this
-    rewrite handles the dict shape correctly.
     """
     sec = ".!?"
     merged = ""
@@ -499,15 +399,6 @@ def merge_and_split_transcripts(transcripts):
 
     return result
 
-
-# ---------------------------------------------------------------------------
-# Swagger / flask-restx models
-# ---------------------------------------------------------------------------
-
-# NOTE: api.model() registrations must use unique names. The original code
-# used 'Transcript' for both the /transcribe ack and the transcript-payload
-# schema, which made flask-restx silently overwrite the first registration
-# and produce a wrong Swagger doc for /transcribe.
 transcribe_input_model = api.model('Transcribe', {
     'audio_b64': fields.String(required=True, description='Base64 encoded audio data'),
     'chunk_id': fields.String(required=True, description='ID of the audio chunk'),
@@ -930,18 +821,6 @@ class TranscriptsSize(Resource):
         t = {k: v for k, v in t.items() if _in_chunk_range(k, fromid, untilid)}
         return jsonify({'size': len(t)})
 
-
-# ---------------------------------------------------------------------------
-# Audio worker auto-start
-# ---------------------------------------------------------------------------
-# The worker thread MUST be started at module-import time, not in
-# ``if __name__ == '__main__':``. Otherwise running under any WSGI server
-# (gunicorn, uwsgi, ``flask run``) leaves the queue with no consumer and
-# ``POST /transcribe`` requests pile up forever.
-#
-# The TRANSCRIBE_AUTOSTART_WORKER env var is honoured for the test suite,
-# which sets it to "false" so a real worker doesn't try to drain queued
-# items (and call out to whisper.cpp) during ``test_transcribe_*``.
 _worker_thread = None
 _worker_lock = threading.Lock()
 
@@ -966,17 +845,8 @@ if _env_bool('TRANSCRIBE_AUTOSTART_WORKER', True):
     _start_worker_once()
 
 
-# ---------------------------------------------------------------------------
-# Entrypoint
-# ---------------------------------------------------------------------------
-
 if __name__ == '__main__':
     # Server bind config is env-driven so the defaults are SAFE:
-    #   - host defaults to 127.0.0.1 (loopback only)
-    #   - debug defaults to False (NEVER bind the Werkzeug debugger on a
-    #     network-reachable port; doing so is remote-code-execution).
-    # Override via FLASK_HOST / FLASK_PORT / FLASK_DEBUG when you really
-    # mean it (e.g. inside a private VM you fully control).
     host = os.getenv('FLASK_HOST', '127.0.0.1')
     port = int(os.getenv('FLASK_PORT', '5040'))
     debug = _env_bool('FLASK_DEBUG', False)
@@ -989,7 +859,5 @@ if __name__ == '__main__':
             host,
         )
 
-    # use_reloader=False because the audio-worker thread above must not be
-    # spawned twice (the reloader runs the module twice, which would
-    # otherwise create a duplicate consumer on the queue).
+    # use_reloader=False because the audio-worker thread above must not be spawned twice (the reloader runs the module twice, which would otherwise create a duplicate consumer on the queue).
     app.run(host=host, port=port, debug=debug, use_reloader=False)

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -63,8 +63,8 @@ else:
     import torch 
     import whisper  
 
-    print("TORCH CUDA:", torch.cuda.is_available())
-    print("DEVICE COUNT:", torch.cuda.device_count())
+    logger.info("TORCH CUDA: %s", torch.cuda.is_available())
+    logger.info("DEVICE COUNT: %s", torch.cuda.device_count())
     logger.info(f"Hardware detection: using {device}")
 
     script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -96,7 +96,8 @@ else:
     import torch  # noqa: WPS433  (deferred import is intentional)
     import whisper  # noqa: WPS433  (deferred import is intentional)
 
-    device = os.getenv('WHISPER_DEVICE', 'cuda' if torch.cuda.is_available() else 'cpu')
+    print("TORCH CUDA:", torch.cuda.is_available())
+    print("DEVICE COUNT:", torch.cuda.device_count())
     logger.info(f"Hardware detection: using {device}")
 
     # Download (or load) two whisper models. If the download via the whisper
@@ -131,14 +132,14 @@ transcripts_lock = threading.Lock()
 audio_stack = queue.Queue()
 
 # Per-source "latest session" registry.
-# Each grabber run calls POST /session?source=<mic|file|url|stdin> at startup;
+# Each grabber run calls POST /session?source=<mic|file|url|stdin|youtube> at startup;
 # the server mints a fresh tenant_id (uuid) and remembers it as the latest
 # tenant_id for that source along with a creation timestamp. Read endpoints
 # accept ?source=<name> as a convenience that resolves to the latest active
 # tenant_id for that source, so the user never has to type or remember the
 # uuid in curl commands. Stale sessions (older than SESSION_TTL_SECONDS)
 # are evicted on resolve.
-VALID_SOURCES = {"mic", "file", "url", "stdin"}
+VALID_SOURCES = {"mic", "file", "url", "stdin", "youtube"}
 latest_session_by_source = {s: None for s in VALID_SOURCES}  # source -> (tenant_id, created_ts) or None
 session_lock = threading.Lock()
 
@@ -213,7 +214,7 @@ def _resolve_tenant(args, default='0000'):
 
     Priority:
       1. Explicit ?tenant_id=<id> wins (covers manual override / debugging).
-      2. ?source=<mic|file|url|stdin> resolves to the most recently
+      2. ?source=<mic|file|url|stdin|youtube> resolves to the most recently
          registered, non-expired session for that source. An unknown
          source value aborts with HTTP 400 so client typos surface
          loudly instead of masquerading as "no transcripts yet". A known
@@ -535,7 +536,7 @@ size_response_model = api.model('SizeResponse', {
 session_input_model = api.model('SessionRequest', {
     'source': fields.String(
         required=True,
-        description='Input source name; one of: mic, file, url, stdin',
+        description='Input source name; one of: mic, file, url, stdin, youtube',
         enum=sorted(VALID_SOURCES),
     ),
 })
@@ -556,10 +557,10 @@ class Session(Resource):
         Start a new transcription session for an input source.
 
         The grabber calls this once per run, passing its source name
-        (mic/file/url/stdin). The server mints a fresh tenant_id (uuid)
-        and records it as the latest session for that source. Subsequent
-        read requests using ?source=<name> resolve to this tenant_id, so
-        the user never has to know or type the uuid.
+        (mic/file/url/stdin/youtube). The server mints a fresh tenant_id
+        (uuid) and records it as the latest session for that source.
+        Subsequent read requests using ?source=<name> resolve to this
+        tenant_id, so the user never has to know or type the uuid.
         '''
         try:
             data = request.get_json(force=True, silent=True) or {}
@@ -627,7 +628,7 @@ class Transcribe(Resource):
 class GetTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'chunk_id' : {'description': 'Chunk ID'},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False}
     })
@@ -656,7 +657,7 @@ class GetTranscript(Resource):
 class GetFirstTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'from'     : {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'}
     })
@@ -688,7 +689,7 @@ class GetFirstTranscript(Resource):
 class PopFirstTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'from'     : {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'}
     })
@@ -704,7 +705,7 @@ class PopFirstTranscript(Resource):
 
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'from'     : {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'}
     })
@@ -748,7 +749,7 @@ class PopFirstTranscript(Resource):
 class GetLatestTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'until': {'description': 'End chunk ID (defaults to "now" in ms)', 'type': 'string'}
     })
@@ -780,7 +781,7 @@ class GetLatestTranscript(Resource):
 class PopLatestTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'until': {'description': 'End chunk ID (defaults to "now" in ms)', 'type': 'string'}
     })
@@ -796,7 +797,7 @@ class PopLatestTranscript(Resource):
 
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'until': {'description': 'End chunk ID (defaults to "now" in ms)', 'type': 'string'}
     })
@@ -840,7 +841,7 @@ class PopLatestTranscript(Resource):
 class DeleteTranscript(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'chunk_id' : {'description': 'Chunk ID', 'type': 'string'}
     })
     @api.response(200, 'Success', transcript_response_model)
@@ -855,7 +856,7 @@ class DeleteTranscript(Resource):
 
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'chunk_id' : {'description': 'Chunk ID', 'type': 'string'}
     })
     @api.response(200, 'Success', transcript_response_model)
@@ -883,7 +884,7 @@ class DeleteTranscript(Resource):
 class ListTranscripts(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'from'     : {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'},
         'until'    : {'description': 'End chunk ID (defaults to "now" in ms)', 'type': 'string'}
@@ -908,7 +909,7 @@ class ListTranscripts(Resource):
 class TranscriptsSize(Resource):
     @api.doc(params={
         'tenant_id': {'description': 'Tenant ID', 'default': '0000'},
-        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin']},
+        'source':    {'description': 'Resolve to the latest session for a source (mic|file|url|stdin). Ignored if tenant_id is given. Unknown values return HTTP 400.', 'type': 'string', 'enum': ['mic', 'file', 'url', 'stdin', 'youtube']},
         'sentences': {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False},
         'from'     : {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'},
         'until'    : {'description': 'End chunk ID (defaults to "now" in ms)', 'type': 'string'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "requests",
     "scipy",
     "torch",
+    "yt-dlp",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Resolves issue #56 , Since, the current 4 audio sources are implemented in a client side approach, I've kept the same architecture for YouTube audio source. The issue proposes a server side audio source, i can implement that in my next PR. 

## Goal

Add YouTube as a 5th client-side audio source, matching the design of the existing mic/file/url/stdin sources. results readable via `?source=youtube`.

---
## Output screenshots: Live stream used for testing [https://youtu.be/xEqUt-p5KyA](https://youtu.be/xEqUt-p5KyA)
### Flask server running
<img width="1394" height="805" alt="youtube server" src="https://github.com/user-attachments/assets/9f6916cc-5923-4dcc-acdd-66d06376b8c2" />

### Youtube live stream: Chunks generated
<img width="1253" height="826" alt="youtube chunk" src="https://github.com/user-attachments/assets/c9a26626-1f51-419f-b53f-8b5765dabf86" />

### Youtube live stream: Transcripts generated 
<img width="1253" height="770" alt="youtube transcripts" src="https://github.com/user-attachments/assets/c3ec5a21-a911-4328-a398-75a68aa0f398" />


---


## Runtime Setup

## Local Testing — YouTube Source

### One-Time Setup

```bash
cd /mnt/c/Users/Dell/Desktop/susi/susi_translator
```

## 1. Install yt-dlp
```bash
uv pip install yt-dlp        # or: python -m ensurepip && python -m pip install yt-dlp
```

## 2. Install Node (for yt-dlp's JS challenge solver)
```bash
sudo apt install -y nodejs
```

## 3. Export YouTube cookies
###   In your browser (logged into youtube.com), use a "Get cookies.txt" extension.
I used [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc)
###    Save the file as: C:\Users\Dell\Desktop\www.youtube.com_cookies.txt


---

### Run

Open three WSL terminals, all `cd`'d into the project root.

**Terminal 1 — server:**

```bash
python flask/transcribe_server.py
```

Wait for `Running on http://127.0.0.1:5040`.

**Terminal 2 — grabber:**

```bash
python flask/audio_grabber.py youtube \
    --url "https://www.youtube.com/watch?v=xEqUt-p5KyA" \
    --cookies "/mnt/c/Users/Dell/Desktop/www.youtube.com_cookies.txt"
```

Wait until you see `Sent chunk … with N bytes` lines.

**Terminal 3 — read transcripts:**

```bash
curl "http://localhost:5040/list_transcripts?source=youtube"
```
some more commands like:
```bash
curl "http://localhost:5040/transcripts_size?source=youtube"
curl -X DELETE "http://localhost:5040/pop_first_transcript?source=youtube"
```
---

### Run the Test Suite

```bash
python -m pytest -q
```

Expected: `91 passed`.

---

### Stop

`Ctrl-C` Terminal 2, then Terminal 1.
   
## Challenges Faced

### 1. YouTube Anti-Bot Protection

This was the biggest challenge. Fixing one issue revealed the next one.

- **Layer 1 — “Sign in to confirm you're not a bot.”**  
YouTube blocked requests from WSL/data-center IPs. Fixed by adding support for browser cookies so users can pass logged-in session cookies. 

- **Layer 2 — “No video formats found” / challenge errors**  
YouTube uses JavaScript challenges that yt-dlp could not solve alone. Fixed by enabling Deno/Node runtimes and auto-downloading the required solver scripts from GitHub.

- **Layer 3 — CLI vs Python API mismatch**  
The CLI and Python API expected different formats for `js_runtimes`. Fixed by checking yt-dlp source code and changing the format to the correct dictionary structure.

---

### 2. Reconnection Handling for Live Streams

- **Problem**  
Live YouTube streams can disconnect because of network issues or rotating HLS manifests. A simple reconnect loop could run forever.

- **Solution**  
Added retry logic with a maximum of 5 attempts and exponential backoff. Temporary drops reconnect smoothly, while permanently ended streams stop after repeated failures.

---

### 3. Safe URL Validation

- **Problem**  
A weak hostname check could allow fake domains like `youtube.com.evil.example`.

- **Solution**  
Used a strict allow-list of valid YouTube domains and added tests to ensure fake look-alike domains are rejected.

---
## Files Changed

### `flask/audio_sources.py`

New `YouTubeSource` class. Validates URL in `__init__` (allow-list of YouTube hosts; same defensive checks as `URLSource`). Resolves the watch URL via the yt-dlp Python API (lazy import), then pipes through ffmpeg with the same `-protocol_whitelist` as `URLSource`.

Bounded auto-reconnect on stream interruption (5 attempts, exponential backoff 1s→16s, counter resets on first successful chunk after respawn). Accepts optional `cookies_path` and `cookies_from_browser` (mutually exclusive). yt-dlp opts include `js_runtimes={"deno":{},"node":{}}` and `remote_components=["ejs:github"]` so it works on any host with Deno or Node and auto-fetches the EJS challenge-solver scripts from GitHub.

### `flask/audio_grabber.py`

Added `youtube` subcommand. Flags: `--url` (required), `--format` (default `bestaudio/best`), and a mutually exclusive group of `--cookies <path>` / `--cookies-from-browser <name>` for YouTube's bot challenge. Imports `YouTubeSource`, extends `VALID_SOURCES`, updates module docstring and parser metavar/description.

### `flask/transcribe_server.py`

Server-side: added `"youtube"` to `VALID_SOURCES` set so `/session?source=youtube` and all read endpoints accept it. Updated 11 Swagger enum literals via `replaceAll` and 4 prose references in comments/docstrings. No changes to the queue, worker, storage, or any of the 7 read endpoints — they pick up the new source automatically.

### `flask/tests/test_youtube_source_security.py`

New test file mirroring `test_url_source_security.py`. 20 validation tests covering valid YouTube URLs, look-alike host rejection (`youtube.com.evil.example`), non-string input, validator-runs-in-`__init__` guarantee, and cookies mutual-exclusion check. All network-free.

### `pyproject.toml`

Added `yt-dlp` to dependencies.

---

## What Stayed Untouched

The existing 4 audio sources, the queue + worker thread, transcript storage, all 7 transcript-read endpoints, `/transcribe`, `/session`, and every existing test. Strictly additive integration.
