### PR TITLE
feat(core): implement lazy-loading factories for translation providers

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,9 +1,11 @@
 from .base import TranslationProvider, TranslationError, ProviderConfigError
-from .registry import ProviderRegistry
+from .registry import ProviderRegistry, register_provider, available_providers
 
 __all__ = [
     "TranslationProvider",
     "TranslationError",
     "ProviderConfigError",
     "ProviderRegistry",
+    "register_provider",
+    "available_providers",
 ]

--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,9 @@
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -24,6 +24,9 @@ class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.
 
+    To ensure fast startup times, heavy model initializations are strictly 
+    deferred until a translation is actually requested, rather than loading at import time.
+    
     The translate method leverages kwargs to remain extensible, allowing you to easily pass 
     provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
     to alter the base signature.
@@ -51,20 +54,20 @@ class TranslationProvider(ABC):
         **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
         'formality' for DeepL).
         """
-        pass
+        ...
 
     @abstractmethod
     def is_available(self) -> bool:
         """
         Check if the provider is healthy and ready to serve requests.
         """
-        pass
+        ...
 
     @property
     @abstractmethod
     def provider_name(self) -> str:
         """
-        The canonical, machine-readable name of the provider,
-        Use in logging, telemetry, and registry lookups.
+        The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
+        Used heavily in logging, telemetry, and registry lookups.
         """
-        pass
+        ...

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,70 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class TranslationProvider(ABC):
+    """
+    Abstract base class for all translation and LLM providers.
+
+    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    to alter the base signature.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the provider with necessary configuration.
+        This can include API keys, model paths, or any other settings required 
+        for the provider to function.
+        """
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translate text from source_lang to target_lang.
+        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
+        'formality' for DeepL).
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the provider is healthy and ready to serve requests.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """
+        The canonical, machine-readable name of the provider,
+        Use in logging, telemetry, and registry lookups.
+        """
+        pass

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,55 +1,106 @@
 """
-Basic provider registry for Translator,
-This manages the registration and retrieval of translation providers
+provider registry for Translator.
+This module manages the deferred instantiation of translation providers
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+import threading
+from typing import Any, Callable, Dict, List, Optional
 
-from .base import TranslationProvider, TranslationError
+from .base import TranslationProvider, TranslationError, ProviderConfigError
 
 logger = logging.getLogger(__name__)
 
+# Registry of provider factories
+_PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
+
+
+def register_provider(
+    name: str, 
+    factory: Callable[[Dict[str, Any]], TranslationProvider]
+) -> None:
+    """Register a provider factory under a canonical name"""
+    _PROVIDER_FACTORIES[name] = factory
+    logger.debug(f"Registered translation provider factory: {name}")
+
+
+def available_providers() -> List[str]:
+    """Return list of all registered provider names"""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
 class ProviderRegistry:
     """
-    A simple registry to hold instantiated translation providers.
+    A registry that defers translation provider instantiation until first use
+    to minimize startup time and memory footprint.
     """
-
     def __init__(self):
-        self._providers: Dict[str, TranslationProvider] = {}
+        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
+        self._providers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
 
-    def register(self, provider: TranslationProvider) -> None:
+    def configure(
+        self,
+        provider_name: str,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
         """
-        Registers an already-instantiated translation provider
+        Configure a provider's settings before instantiation.
         """
-        self._providers[provider.provider_name] = provider
-        logger.info(f"Registered translation provider: {provider.provider_name}")
+        if provider_name not in _PROVIDER_FACTORIES:
+            raise ValueError(
+                f"Unknown provider '{provider_name}'. "
+                f"Available: {available_providers()}"
+            )
 
-    def get_provider(self, provider_name: str) -> TranslationProvider:
-        """
-        Retrieves a provider by name, Raises ValueError if the provider is not registered.
-        """
-        if provider_name not in self._providers:
-            raise ValueError(f"Provider '{provider_name}' is not registered.")
-        return self._providers[provider_name]
+        # Bundle the config as expected by base.py
+        config_dict = {"api_key": api_key, **kwargs}
+        
+        with self._lock:
+            self._providers[provider_name] = {
+                "config": config_dict,
+                "instance": None,  # Instantiated lazily on first use
+            }
+            
+        logger.info(f"Configured lazy provider '{provider_name}'")
 
     def translate(
-        self, 
-        provider_name: str, 
-        text: str, 
-        source_lang: str, 
-        target_lang: str, 
+        self,
+        provider_name: str,
+        text: str,
+        source_lang: str,
+        target_lang: str,
         **kwargs: Any
     ) -> str:
         """
-        Translates text using the specified provider
+        Translates text, lazily instantiating the provider if necessary.
         """
-        provider = self.get_provider(provider_name)
+        entry = self._providers.get(provider_name)
         
+        if entry is None:
+            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+
+        # Lazy Instantiation with Double-Checked Locking
+        if entry["instance"] is None:
+            with self._lock:
+                # Check again inside the lock to prevent a race condition
+                if entry["instance"] is None:
+                    factory = _PROVIDER_FACTORIES[provider_name]
+                    try:
+                        instance = factory(entry["config"])
+                        entry["instance"] = instance
+                        logger.info(f"Lazily instantiated '{provider_name}'")
+                    except Exception as e:
+                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        raise ProviderConfigError(f"Provider initialization failed: {e}")
+
+        provider: TranslationProvider = entry["instance"]
+
         if not provider.is_available():
             raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
-            
+
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,55 @@
+"""
+Basic provider registry for Translator,
+This manages the registration and retrieval of translation providers
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .base import TranslationProvider, TranslationError
+
+logger = logging.getLogger(__name__)
+
+class ProviderRegistry:
+    """
+    A simple registry to hold instantiated translation providers.
+    """
+
+    def __init__(self):
+        self._providers: Dict[str, TranslationProvider] = {}
+
+    def register(self, provider: TranslationProvider) -> None:
+        """
+        Registers an already-instantiated translation provider
+        """
+        self._providers[provider.provider_name] = provider
+        logger.info(f"Registered translation provider: {provider.provider_name}")
+
+    def get_provider(self, provider_name: str) -> TranslationProvider:
+        """
+        Retrieves a provider by name, Raises ValueError if the provider is not registered.
+        """
+        if provider_name not in self._providers:
+            raise ValueError(f"Provider '{provider_name}' is not registered.")
+        return self._providers[provider_name]
+
+    def translate(
+        self, 
+        provider_name: str, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translates text using the specified provider
+        """
+        provider = self.get_provider(provider_name)
+        
+        if not provider.is_available():
+            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -90,7 +90,7 @@ class ProviderRegistry:
                         entry["instance"] = instance
                         logger.info(f"Lazily instantiated '{provider_name}'")
                     except Exception as e:
-                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        logger.exception(f"Failed to instantiate '{provider_name}': {e}")
                         raise ProviderConfigError(f"Provider initialization failed: {e}")
 
         provider: TranslationProvider = entry["instance"]

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -37,7 +37,6 @@ class ProviderRegistry:
     to minimize startup time and memory footprint.
     """
     def __init__(self):
-        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
         self._providers: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
 
@@ -47,24 +46,21 @@ class ProviderRegistry:
         api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
-        """
-        Configure a provider's settings before instantiation.
-        """
         if provider_name not in _PROVIDER_FACTORIES:
             raise ValueError(
                 f"Unknown provider '{provider_name}'. "
                 f"Available: {available_providers()}"
             )
 
-        # Bundle the config as expected by base.py
         config_dict = {"api_key": api_key, **kwargs}
-        
+
         with self._lock:
             self._providers[provider_name] = {
                 "config": config_dict,
-                "instance": None,  # Instantiated lazily on first use
+                "factory": _PROVIDER_FACTORIES[provider_name],
+                "instance": None,
             }
-            
+
         logger.info(f"Configured lazy provider '{provider_name}'")
 
     def translate(
@@ -88,7 +84,7 @@ class ProviderRegistry:
             with self._lock:
                 # Check again inside the lock to prevent a race condition
                 if entry["instance"] is None:
-                    factory = _PROVIDER_FACTORIES[provider_name]
+                    factory = entry["factory"]
                     try:
                         instance = factory(entry["config"])
                         entry["instance"] = instance

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,17 +1,35 @@
 """
-Tests covering the base translation provider architecture and 
-basic registry functionality for susi_translator.
+tests covering the translation provider architecture, 
+ensuring the abstract interface and double-checked locking behave as expected
 """
 
 from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
 import pytest
 
-from providers.base import TranslationProvider, TranslationError
-from providers.registry import ProviderRegistry
+from providers.base import TranslationProvider, TranslationError, ProviderConfigError
+from providers.registry import (
+    ProviderRegistry,
+    register_provider,
+    available_providers,
+)
 
-#concrete providers
+#concrete providers used in tests
 class EchoProvider(TranslationProvider):
-    """Returns the input text unchanged."""
+    """Returns the input text unchanged. Tracks instantiation count."""
+
+    instantiation_count = 0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Enforces threads to collide in the concurrency test
+        # to guarantee the double-checked lock is actually tested
+        time.sleep(0.05) 
+        EchoProvider.instantiation_count += 1
+
     def translate(self, text, source_lang, target_lang, **kwargs):
         return text
 
@@ -22,20 +40,36 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
-class UnavailableProvider(TranslationProvider):
-    """Always reports itself as unavailable."""
+class FailingProvider(TranslationProvider):
+    """Raises TranslationError on every translate() call."""
     def translate(self, text, source_lang, target_lang, **kwargs):
-        raise TranslationError("This provider is unavailable")
+        raise TranslationError("intentional failure")
 
     def is_available(self):
-        return False
+        return True
 
     @property
     def provider_name(self):
-        return "unavailable"
+        return "failing"
 
+class ConfigCapturingProvider(TranslationProvider):
+    """Stores the config it receives so tests can assert on it."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.received_config = dict(self.config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "config_capturing"
+    
 class KwargsCapturingProvider(TranslationProvider):
-    """Stores the kwargs passed to translate() so tests can assert on them."""
+    """Stores the kwargs passed to translate() so tests can assert on them"""
     def __init__(self, config=None):
         super().__init__(config)
         self.last_kwargs = {}
@@ -52,8 +86,19 @@ class KwargsCapturingProvider(TranslationProvider):
         return "kwargs_capturing"
 
 
-#Abstract interfaces
+#Fixtures
 
+@pytest.fixture(autouse=True)
+def clean_factories():
+    with patch("providers.registry._PROVIDER_FACTORIES", {}) as mock_dict:
+        yield mock_dict
+
+@pytest.fixture
+def registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+#Abstract interface test
 class TestAbstractInterface:
     def test_cannot_instantiate_abstract_class(self) -> None:
         with pytest.raises(TypeError):
@@ -75,42 +120,103 @@ class TestAbstractInterface:
         assert provider.config["api_key"] == "secret"
 
 
-#Registry Tests
+#Registration & Configuration tests
+class TestProviderRegistration:
+    def test_register_and_list(self) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        assert "echo" in available_providers()
 
-class TestBasicRegistry:
-    def test_register_and_retrieve(self):
-        registry = ProviderRegistry()
-        provider = EchoProvider()
+class TestRegistryConfigure:
+    def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        registry.configure("config_capturing", api_key="secret-key")
         
-        registry.register(provider)
-        retrieved = registry.get_provider("echo")
-        
-        assert retrieved is provider
+        registry.translate("config_capturing", "hello", "en", "de")
+        instance = registry._providers["config_capturing"]["instance"]
+        assert instance.received_config["api_key"] == "secret-key"
 
-    def test_unregistered_provider_raises_error(self):
-        registry = ProviderRegistry()
-        with pytest.raises(ValueError, match="is not registered"):
-            registry.get_provider("missing")
 
-    def test_translate_routes_correctly(self):
-        registry = ProviderRegistry()
-        registry.register(EchoProvider())
+#Lazy instantiation tests
+class TestLazyInstantiation:
+    def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
         
-        result = registry.translate("echo", "hello", "en", "es")
-        assert result == "hello"
+        # Instance should be None before translation
+        assert registry._providers["echo"]["instance"] is None
+        
+        registry.translate("echo", "hello", "en", "de")
+        
+        # Instance should exist after translation
+        assert registry._providers["echo"]["instance"] is not None
 
-    def test_translate_checks_availability(self):
-        registry = ProviderRegistry()
-        registry.register(UnavailableProvider())
-        
-        # It should check `is_available()` and throw an error before trying to translate
-        with pytest.raises(RuntimeError, match="currently unavailable"):
-            registry.translate("unavailable", "hello", "en", "es")
 
-    def test_translate_forwards_kwargs(self):
-        registry = ProviderRegistry()
-        provider = KwargsCapturingProvider()
-        registry.register(provider)
+#Translation tests
+class TestTranslate:
+    def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
+        """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
+        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
+        registry.configure("kwargs_capturing")
         
-        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
-        assert provider.last_kwargs == {"temperature": 0.7}
+        registry.translate(
+            "kwargs_capturing", 
+            "hello", 
+            "en", 
+            "de", 
+            temperature=0.3, 
+            formality="informal"
+        )
+        
+        instance = registry._providers["kwargs_capturing"]["instance"]
+        assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
+
+    def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
+        """Ensure runtime TranslationErrors from the provider are properly propagated."""
+        register_provider("failing", lambda config: FailingProvider(config))
+        registry.configure("failing")
+        
+        with pytest.raises(TranslationError, match="intentional failure"):
+            registry.translate("failing", "hello", "en", "de")
+
+    def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
+        """Ensure errors during lazy initialization are caught and wrapped correctly."""
+        def bad_factory(config):
+            raise RuntimeError("missing heavy ML weights")
+
+        register_provider("broken", bad_factory)
+        registry.configure("broken")
+        
+        with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
+            registry.translate("broken", "hello", "en", "de")
+
+
+# Thread safety test 
+class TestThreadSafety:
+    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating simultaneously must not bypass the lock."""
+        EchoProvider.instantiation_count = 0
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                # All 20 threads will smash into the lock simultaneously here.
+                result = registry.translate("echo", "hello", "en", "de")
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert all(r == "hello" for r in results)
+        
+        # PROOF: Even with 20 threads colliding, the model was only loaded into RAM exactly once.
+        assert EchoProvider.instantiation_count == 1

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,116 @@
+"""
+Tests covering the base translation provider architecture and 
+basic registry functionality for susi_translator.
+"""
+
+from __future__ import annotations
+import pytest
+
+from providers.base import TranslationProvider, TranslationError
+from providers.registry import ProviderRegistry
+
+#concrete providers
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
+
+
+#Abstract interfaces
+
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+#Registry Tests
+
+class TestBasicRegistry:
+    def test_register_and_retrieve(self):
+        registry = ProviderRegistry()
+        provider = EchoProvider()
+        
+        registry.register(provider)
+        retrieved = registry.get_provider("echo")
+        
+        assert retrieved is provider
+
+    def test_unregistered_provider_raises_error(self):
+        registry = ProviderRegistry()
+        with pytest.raises(ValueError, match="is not registered"):
+            registry.get_provider("missing")
+
+    def test_translate_routes_correctly(self):
+        registry = ProviderRegistry()
+        registry.register(EchoProvider())
+        
+        result = registry.translate("echo", "hello", "en", "es")
+        assert result == "hello"
+
+    def test_translate_checks_availability(self):
+        registry = ProviderRegistry()
+        registry.register(UnavailableProvider())
+        
+        # It should check `is_available()` and throw an error before trying to translate
+        with pytest.raises(RuntimeError, match="currently unavailable"):
+            registry.translate("unavailable", "hello", "en", "es")
+
+    def test_translate_forwards_kwargs(self):
+        registry = ProviderRegistry()
+        provider = KwargsCapturingProvider()
+        registry.register(provider)
+        
+        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
+        assert provider.last_kwargs == {"temperature": 0.7}

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -216,7 +216,8 @@ class TestThreadSafety:
             t.join()
 
         assert errors == [], f"Unexpected errors: {errors}"
+        assert len(results) == 20
         assert all(r == "hello" for r in results)
         
-        # PROOF: Even with 20 threads colliding, the model was only loaded into RAM exactly once.
+        #Even with 20 threads colliding, the model was only loaded into RAM exactly once
         assert EchoProvider.instantiation_count == 1


### PR DESCRIPTION
**Note: This is a stacked PR built on top of #61  . The "Files Changed" tab currently includes previous commits from the base architecture. It will clean up automatically once #61  is merged into main.**

**Description:**
Fixes #62 

This PR introduces lazy-loading factories to the translation provider architecture. To optimize server startup time and memory footprint, heavy ML models are now strictly deferred until the first actual `translate()` request.

**Changes:**
* Updated `ProviderRegistry` to accept factory functions instead of instantiated objects.
* Implemented Just-In-Time (JIT) instantiation inside `translate()`.
* Added a double-checked `threading.Lock()` to prevent concurrent requests from triggering multiple heavy model initializations simultaneously.
* Expanded the pytest suite with multi-thread concurrency tests to prove lock safety.

## Reviewer's Guide:
This PR introduces lazy-loading factories and thread-safe concurrency to the translation provider architecture. To optimize server startup time and memory footprint, heavy ML models are now strictly deferred until the first actual translate() request. There are no user-facing API endpoints in this step.
 
the registry now accepts standard Python callables that wrap provider instantiation instead of accepting raw objects. These factories ensure that resource intensive operations like parsing model configurations, allocating CUDA memory, or initializing heavy local translation instances, are completely skipped during the registry registration phase. 

Additionally, mock factories are defined within the test suite to mimic both successful cold starts and initialization failures, ensuring the factory lifecycle works correctly under heavy load.

***how to test this PR***
Because this PR introduceslazy-loading factories and thread-safe concurrency to the translation provider architecture rather than user facing API routes, the verification is entirely handled via the automated unit test suite
- Sync your environment:

```bash
uv sync
```

- Run the provider architecture test file: 
Navigate to the flask/tests directory and execute:
```bash
uv run pytest test_provider_architecture.py
```
***exxpected outcome***

<img width="1889" height="222" alt="image" src="https://github.com/user-attachments/assets/febdc2b9-91f5-4609-9f37-08871a0ce31c" />
