### PR TITLE
implementation of tenant isolation for translation providers

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,9 +1,11 @@
 from .base import TranslationProvider, TranslationError, ProviderConfigError
-from .registry import ProviderRegistry
+from .registry import ProviderRegistry, register_provider, available_providers
 
 __all__ = [
     "TranslationProvider",
     "TranslationError",
     "ProviderConfigError",
     "ProviderRegistry",
+    "register_provider",
+    "available_providers",
 ]

--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,9 @@
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -24,6 +24,9 @@ class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.
 
+    To ensure fast startup times, heavy model initializations are strictly 
+    deferred until a translation is actually requested, rather than loading at import time.
+    
     The translate method leverages kwargs to remain extensible, allowing you to easily pass 
     provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
     to alter the base signature.
@@ -51,20 +54,20 @@ class TranslationProvider(ABC):
         **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
         'formality' for DeepL).
         """
-        pass
+        ...
 
     @abstractmethod
     def is_available(self) -> bool:
         """
         Check if the provider is healthy and ready to serve requests.
         """
-        pass
+        ...
 
     @property
     @abstractmethod
     def provider_name(self) -> str:
         """
-        The canonical, machine-readable name of the provider,
-        Use in logging, telemetry, and registry lookups.
+        The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
+        Used heavily in logging, telemetry, and registry lookups.
         """
-        pass
+        ...

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -24,18 +24,21 @@ class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.
 
-    To ensure fast startup times, heavy model initializations are strictly 
-    deferred until a translation is actually requested, rather than loading at import time.
+    To ensure fast startup time are strictly deferred until a 
+    translation is actually requested, rather than loading at import time.
+
+    We also enforce tenant isolation by making sure each instance holds its own
+    distinct configuration without relying on shared class-level state. 
     
-    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
-    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    the translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings like, an LLM's temperature or DeepL's formality—without ever having 
     to alter the base signature.
     """
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         """
-        Initialize the provider with necessary configuration.
-        This can include API keys, model paths, or any other settings required 
+        Initializing the provider with tenant-specific configuration,
+        this can include API keys, model paths, or any other settings required 
         for the provider to function.
         """
         # Create a shallow copy to prevent accidental mutation of the original dict
@@ -50,16 +53,17 @@ class TranslationProvider(ABC):
         **kwargs: Any
     ) -> str:
         """
-        Translate text from source_lang to target_lang.
-        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
-        'formality' for DeepL).
+        Translate text from source_lang to target_lang
+        **kwargs: Optional provider specific parameters('temperature' for LLMs, 
+        'formality' for DeepL)
         """
         ...
 
+    #health check to ensure provider is ready to serve requests
     @abstractmethod
     def is_available(self) -> bool:
         """
-        Check if the provider is healthy and ready to serve requests.
+        Check if the provider is healthy and ready to serve requests
         """
         ...
 
@@ -68,6 +72,6 @@ class TranslationProvider(ABC):
     def provider_name(self) -> str:
         """
         The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
-        Used heavily in logging, telemetry, and registry lookups.
+        Used heavily in logging, telemetry, and registry lookups
         """
         ...

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -4,6 +4,7 @@ Translation and LLM provider architecture for susi_translator
 
 from __future__ import annotations
 
+import copy
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
@@ -41,8 +42,8 @@ class TranslationProvider(ABC):
         this can include API keys, model paths, or any other settings required 
         for the provider to function.
         """
-        # Create a shallow copy to prevent accidental mutation of the original dict
-        self.config = dict(config) if config else {}
+        # Create a deep copy to prevent accidental mutation of nested config values
+        self.config = copy.deepcopy(config) if config else {}
 
     @abstractmethod
     def translate(

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,70 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class TranslationProvider(ABC):
+    """
+    Abstract base class for all translation and LLM providers.
+
+    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    to alter the base signature.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the provider with necessary configuration.
+        This can include API keys, model paths, or any other settings required 
+        for the provider to function.
+        """
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translate text from source_lang to target_lang.
+        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
+        'formality' for DeepL).
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the provider is healthy and ready to serve requests.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """
+        The canonical, machine-readable name of the provider,
+        Use in logging, telemetry, and registry lookups.
+        """
+        pass

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,6 +1,7 @@
 """
-provider registry for Translator.
-This module manages the deferred instantiation of translation providers
+Per-tenant provider registry for Susi Translator,
+This module manages the lifecycle of translation 
+providers
 """
 
 from __future__ import annotations
@@ -13,7 +14,8 @@ from .base import TranslationProvider, TranslationError, ProviderConfigError
 
 logger = logging.getLogger(__name__)
 
-# Registry of provider factories
+# Registry of provider factories. Each factory is a callable that takes a config dict
+# and returns a TranslationProvider instance
 _PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
 
 
@@ -21,9 +23,11 @@ def register_provider(
     name: str, 
     factory: Callable[[Dict[str, Any]], TranslationProvider]
 ) -> None:
-    """Register a provider factory under a canonical name"""
+    """
+    Register a provider factory under a canonical name
+    """
     _PROVIDER_FACTORIES[name] = factory
-    logger.debug(f"Registered translation provider factory: {name}")
+    logger.debug(f"Registered translation provider: {name}")
 
 
 def available_providers() -> List[str]:
@@ -33,22 +37,24 @@ def available_providers() -> List[str]:
 
 class ProviderRegistry:
     """
-    A registry that defers translation provider instantiation until first use
-    to minimize startup time and memory footprint.
+    Per-tenant provider registry. One shared instance should be created
+    at module load time in transcribe_server.py and used across all requests
     """
+
     def __init__(self):
-        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
-        self._providers: Dict[str, Dict[str, Any]] = {}
+        # tenant_id -> { "provider_name": str, "config": dict, "instance": Optional[TranslationProvider] }
+        self._tenants: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
 
     def configure(
         self,
+        tenant_id: str,
         provider_name: str,
         api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """
-        Configure a provider's settings before instantiation.
+        Configure a provider for a tenant session.
         """
         if provider_name not in _PROVIDER_FACTORIES:
             raise ValueError(
@@ -58,41 +64,47 @@ class ProviderRegistry:
 
         # Bundle the config as expected by base.py
         config_dict = {"api_key": api_key, **kwargs}
-        
+
         with self._lock:
-            self._providers[provider_name] = {
+            self._tenants[tenant_id] = {
+                "provider_name": provider_name,
                 "config": config_dict,
-                "instance": None,  # Instantiated lazily on first use
+                "instance": None,  # instantiated lazily on first use
             }
             
-        logger.info(f"Configured lazy provider '{provider_name}'")
+        logger.info(
+            f"Configured provider '{provider_name}' for tenant '{tenant_id}'"
+        )
 
     def translate(
         self,
-        provider_name: str,
+        tenant_id: str,
         text: str,
         source_lang: str,
         target_lang: str,
         **kwargs: Any
-    ) -> str:
+    ) -> Optional[str]:
         """
-        Translates text, lazily instantiating the provider if necessary.
+        Translate text for a given tenant using their configured provider.
         """
-        entry = self._providers.get(provider_name)
-        
+        #Fast, lock-free read to get the tenant entry
+        entry = self._tenants.get(tenant_id)
         if entry is None:
-            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+            return None  # no translation configured for this tenant
 
-        # Lazy Instantiation with Double-Checked Locking
+        #Lazy Instantiation with Double-Checked Locking
         if entry["instance"] is None:
             with self._lock:
-                # Check again inside the lock to prevent a race condition
+                
                 if entry["instance"] is None:
+                    provider_name = entry["provider_name"]
                     factory = _PROVIDER_FACTORIES[provider_name]
+                    
                     try:
+                        # Pass the bundled config dict to match base.py
                         instance = factory(entry["config"])
                         entry["instance"] = instance
-                        logger.info(f"Lazily instantiated '{provider_name}'")
+                        logger.info(f"Lazily instantiated '{provider_name}' for tenant '{tenant_id}'")
                     except Exception as e:
                         logger.error(f"Failed to instantiate '{provider_name}': {e}")
                         raise ProviderConfigError(f"Provider initialization failed: {e}")
@@ -100,7 +112,22 @@ class ProviderRegistry:
         provider: TranslationProvider = entry["instance"]
 
         if not provider.is_available():
-            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            logger.warning(
+                f"Provider '{provider.provider_name}' is not available "
+                f"for tenant '{tenant_id}'"
+            )
+            return None
 
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)
+
+    def remove(self, tenant_id: str) -> None:
+        """Remove provider config for a tenant"""
+        with self._lock:
+            self._tenants.pop(tenant_id, None)
+
+    def get_provider_name(self, tenant_id: str) -> Optional[str]:
+        """Return the configured provider name for a tenant, or None."""
+        with self._lock:
+            entry = self._tenants.get(tenant_id)
+            return entry["provider_name"] if entry else None

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,55 +1,106 @@
 """
-Basic provider registry for Translator,
-This manages the registration and retrieval of translation providers
+provider registry for Translator.
+This module manages the deferred instantiation of translation providers
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+import threading
+from typing import Any, Callable, Dict, List, Optional
 
-from .base import TranslationProvider, TranslationError
+from .base import TranslationProvider, TranslationError, ProviderConfigError
 
 logger = logging.getLogger(__name__)
 
+# Registry of provider factories
+_PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
+
+
+def register_provider(
+    name: str, 
+    factory: Callable[[Dict[str, Any]], TranslationProvider]
+) -> None:
+    """Register a provider factory under a canonical name"""
+    _PROVIDER_FACTORIES[name] = factory
+    logger.debug(f"Registered translation provider factory: {name}")
+
+
+def available_providers() -> List[str]:
+    """Return list of all registered provider names"""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
 class ProviderRegistry:
     """
-    A simple registry to hold instantiated translation providers.
+    A registry that defers translation provider instantiation until first use
+    to minimize startup time and memory footprint.
     """
-
     def __init__(self):
-        self._providers: Dict[str, TranslationProvider] = {}
+        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
+        self._providers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
 
-    def register(self, provider: TranslationProvider) -> None:
+    def configure(
+        self,
+        provider_name: str,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
         """
-        Registers an already-instantiated translation provider
+        Configure a provider's settings before instantiation.
         """
-        self._providers[provider.provider_name] = provider
-        logger.info(f"Registered translation provider: {provider.provider_name}")
+        if provider_name not in _PROVIDER_FACTORIES:
+            raise ValueError(
+                f"Unknown provider '{provider_name}'. "
+                f"Available: {available_providers()}"
+            )
 
-    def get_provider(self, provider_name: str) -> TranslationProvider:
-        """
-        Retrieves a provider by name, Raises ValueError if the provider is not registered.
-        """
-        if provider_name not in self._providers:
-            raise ValueError(f"Provider '{provider_name}' is not registered.")
-        return self._providers[provider_name]
+        # Bundle the config as expected by base.py
+        config_dict = {"api_key": api_key, **kwargs}
+        
+        with self._lock:
+            self._providers[provider_name] = {
+                "config": config_dict,
+                "instance": None,  # Instantiated lazily on first use
+            }
+            
+        logger.info(f"Configured lazy provider '{provider_name}'")
 
     def translate(
-        self, 
-        provider_name: str, 
-        text: str, 
-        source_lang: str, 
-        target_lang: str, 
+        self,
+        provider_name: str,
+        text: str,
+        source_lang: str,
+        target_lang: str,
         **kwargs: Any
     ) -> str:
         """
-        Translates text using the specified provider
+        Translates text, lazily instantiating the provider if necessary.
         """
-        provider = self.get_provider(provider_name)
+        entry = self._providers.get(provider_name)
         
+        if entry is None:
+            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+
+        # Lazy Instantiation with Double-Checked Locking
+        if entry["instance"] is None:
+            with self._lock:
+                # Check again inside the lock to prevent a race condition
+                if entry["instance"] is None:
+                    factory = _PROVIDER_FACTORIES[provider_name]
+                    try:
+                        instance = factory(entry["config"])
+                        entry["instance"] = instance
+                        logger.info(f"Lazily instantiated '{provider_name}'")
+                    except Exception as e:
+                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        raise ProviderConfigError(f"Provider initialization failed: {e}")
+
+        provider: TranslationProvider = entry["instance"]
+
         if not provider.is_available():
             raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
-            
+
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,55 @@
+"""
+Basic provider registry for Translator,
+This manages the registration and retrieval of translation providers
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .base import TranslationProvider, TranslationError
+
+logger = logging.getLogger(__name__)
+
+class ProviderRegistry:
+    """
+    A simple registry to hold instantiated translation providers.
+    """
+
+    def __init__(self):
+        self._providers: Dict[str, TranslationProvider] = {}
+
+    def register(self, provider: TranslationProvider) -> None:
+        """
+        Registers an already-instantiated translation provider
+        """
+        self._providers[provider.provider_name] = provider
+        logger.info(f"Registered translation provider: {provider.provider_name}")
+
+    def get_provider(self, provider_name: str) -> TranslationProvider:
+        """
+        Retrieves a provider by name, Raises ValueError if the provider is not registered.
+        """
+        if provider_name not in self._providers:
+            raise ValueError(f"Provider '{provider_name}' is not registered.")
+        return self._providers[provider_name]
+
+    def translate(
+        self, 
+        provider_name: str, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translates text using the specified provider
+        """
+        provider = self.get_provider(provider_name)
+        
+        if not provider.is_available():
+            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -42,7 +42,6 @@ class ProviderRegistry:
     """
 
     def __init__(self):
-        # tenant_id -> { "provider_name": str, "config": dict, "instance": Optional[TranslationProvider] }
         self._tenants: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
 
@@ -57,7 +56,7 @@ class ProviderRegistry:
         Configure a provider for a tenant session.
         """
         if provider_name not in _PROVIDER_FACTORIES:
-            raise ValueError(
+            raise ProviderConfigError(
                 f"Unknown provider '{provider_name}'. "
                 f"Available: {available_providers()}"
             )
@@ -85,17 +84,26 @@ class ProviderRegistry:
         **kwargs: Any
     ) -> Optional[str]:
         """
-        Translate text for a given tenant using their configured provider.
+        Translate text for a given tenant using their configured provider
+        Returns None if the tenant has no configured provider or if the configured
+        provider reports itself as unavailable
         """
-        #Fast, lock-free read to get the tenant entry
+        # Fast, lock-free read to get the tenant entry
         entry = self._tenants.get(tenant_id)
         if entry is None:
             return None  # no translation configured for this tenant
 
-        #Lazy Instantiation with Double-Checked Locking
+        # Lazy Instantiation with Double-Checked Locking
         if entry["instance"] is None:
             with self._lock:
+                # Re-fetch the entry inside the lock to prevent mutating a stale/orphaned dict
+                # if configure() or remove() was called by another thread while we waited
+                entry = self._tenants.get(tenant_id)
                 
+                # If the entry was removed entirely while we waited, abort safely
+                if entry is None:
+                    return None 
+
                 if entry["instance"] is None:
                     provider_name = entry["provider_name"]
                     factory = _PROVIDER_FACTORIES[provider_name]
@@ -106,7 +114,7 @@ class ProviderRegistry:
                         entry["instance"] = instance
                         logger.info(f"Lazily instantiated '{provider_name}' for tenant '{tenant_id}'")
                     except Exception as e:
-                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        logger.exception(f"Failed to instantiate '{provider_name}': {e}")
                         raise ProviderConfigError(f"Provider initialization failed: {e}")
 
         provider: TranslationProvider = entry["instance"]

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,6 +1,7 @@
 """
-tests covering the translation provider architecture, 
-ensuring the abstract interface and double-checked locking behave as expected
+Tests covers the translation provider architecture, ensuring that the 
+abstract interface is correctly defined and that the provider registry 
+behaves as expected
 """
 
 from __future__ import annotations
@@ -17,7 +18,8 @@ from providers.registry import (
     available_providers,
 )
 
-#concrete providers used in tests
+# Minimal concrete providers for testing 
+
 class EchoProvider(TranslationProvider):
     """Returns the input text unchanged. Tracks instantiation count."""
 
@@ -25,7 +27,7 @@ class EchoProvider(TranslationProvider):
 
     def __init__(self, config=None):
         super().__init__(config)
-        # Enforces threads to collide in the concurrency test
+        # enforces threads to collide in the concurrency test
         # to guarantee the double-checked lock is actually tested
         time.sleep(0.05) 
         EchoProvider.instantiation_count += 1
@@ -40,8 +42,26 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
 class FailingProvider(TranslationProvider):
     """Raises TranslationError on every translate() call."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
     def translate(self, text, source_lang, target_lang, **kwargs):
         raise TranslationError("intentional failure")
 
@@ -68,6 +88,7 @@ class ConfigCapturingProvider(TranslationProvider):
     def provider_name(self):
         return "config_capturing"
     
+
 class KwargsCapturingProvider(TranslationProvider):
     """Stores the kwargs passed to translate() so tests can assert on them"""
     def __init__(self, config=None):
@@ -86,6 +107,7 @@ class KwargsCapturingProvider(TranslationProvider):
         return "kwargs_capturing"
 
 
+
 #Fixtures
 
 @pytest.fixture(autouse=True)
@@ -98,7 +120,7 @@ def registry() -> ProviderRegistry:
     return ProviderRegistry()
 
 
-#Abstract interface test
+#Abstract interface tests
 class TestAbstractInterface:
     def test_cannot_instantiate_abstract_class(self) -> None:
         with pytest.raises(TypeError):
@@ -120,46 +142,55 @@ class TestAbstractInterface:
         assert provider.config["api_key"] == "secret"
 
 
-#Registration & Configuration tests
+
+#Registration tests
 class TestProviderRegistration:
     def test_register_and_list(self) -> None:
         register_provider("echo", lambda config: EchoProvider(config))
         assert "echo" in available_providers()
 
+
+
+#Registry configuration tests
 class TestRegistryConfigure:
     def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
         register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
-        registry.configure("config_capturing", api_key="secret-key")
+        registry.configure("tenant1", "config_capturing", api_key="secret-key")
         
-        registry.translate("config_capturing", "hello", "en", "de")
-        instance = registry._providers["config_capturing"]["instance"]
+        registry.translate("tenant1", "hello", "en", "de")
+        instance = registry._tenants["tenant1"]["instance"]
         assert instance.received_config["api_key"] == "secret-key"
 
 
 #Lazy instantiation tests
+
 class TestLazyInstantiation:
     def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
         register_provider("echo", lambda config: EchoProvider(config))
-        registry.configure("echo")
+        registry.configure("tenant1", "echo")
         
         # Instance should be None before translation
-        assert registry._providers["echo"]["instance"] is None
+        assert registry._tenants["tenant1"]["instance"] is None
         
-        registry.translate("echo", "hello", "en", "de")
+        registry.translate("tenant1", "hello", "en", "de")
         
         # Instance should exist after translation
-        assert registry._providers["echo"]["instance"] is not None
+        assert registry._tenants["tenant1"]["instance"] is not None
 
 
-#Translation tests
+
+# Translation tests
 class TestTranslate:
     def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
         """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
-        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
-        registry.configure("kwargs_capturing")
+        register_provider(
+            "kwargs_capturing", 
+            lambda config: KwargsCapturingProvider(config)
+        )
+        registry.configure("tenant1", "kwargs_capturing")
         
         registry.translate(
-            "kwargs_capturing", 
+            "tenant1", 
             "hello", 
             "en", 
             "de", 
@@ -167,16 +198,17 @@ class TestTranslate:
             formality="informal"
         )
         
-        instance = registry._providers["kwargs_capturing"]["instance"]
+        instance = registry._tenants["tenant1"]["instance"]
         assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
 
     def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
         """Ensure runtime TranslationErrors from the provider are properly propagated."""
         register_provider("failing", lambda config: FailingProvider(config))
-        registry.configure("failing")
+        registry.configure("tenant1", "failing")
         
+        # The provider is designed to fail when translate is called
         with pytest.raises(TranslationError, match="intentional failure"):
-            registry.translate("failing", "hello", "en", "de")
+            registry.translate("tenant1", "hello", "en", "de")
 
     def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
         """Ensure errors during lazy initialization are caught and wrapped correctly."""
@@ -184,27 +216,51 @@ class TestTranslate:
             raise RuntimeError("missing heavy ML weights")
 
         register_provider("broken", bad_factory)
-        registry.configure("broken")
+        registry.configure("tenant1", "broken")
         
+        # The initialization happens lazily during the first translate call.
+        # It should catch the RuntimeError and wrap it in a ProviderConfigError.
         with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
-            registry.translate("broken", "hello", "en", "de")
+            registry.translate("tenant1", "hello", "en", "de")
 
 
-# Thread safety test 
+# Translation & Multi-tenant tests
+
+class TestMultiTenantIsolation:
+    def test_tenant_config_is_isolated(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        
+        registry.configure("tenant_a", "config_capturing", api_key="key-a")
+        registry.configure("tenant_b", "config_capturing", api_key="key-b")
+
+        registry.translate("tenant_a", "x", "en", "de")
+        registry.translate("tenant_b", "x", "en", "de")
+
+        instance_a = registry._tenants["tenant_a"]["instance"]
+        instance_b = registry._tenants["tenant_b"]["instance"]
+
+        assert instance_a.received_config["api_key"] == "key-a"
+        assert instance_b.received_config["api_key"] == "key-b"
+        assert instance_a is not instance_b
+
+
+
+# Thread safety test
 class TestThreadSafety:
-    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
-        """Multiple threads translating simultaneously must not bypass the lock."""
+    def test_concurrent_translate_same_tenant(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating for the same tenant must not bypass the lock."""
         EchoProvider.instantiation_count = 0
         register_provider("echo", lambda config: EchoProvider(config))
-        registry.configure("echo")
+        registry.configure("tenant1", "echo")
 
         results = []
         errors = []
 
         def worker():
             try:
-                # All 20 threads will smash into the lock simultaneously here.
-                result = registry.translate("echo", "hello", "en", "de")
+                # Due to the time.sleep in EchoProvider, all 20 threads will 
+                # smash into the lock simultaneously here.
+                result = registry.translate("tenant1", "hello", "en", "de")
                 results.append(result)
             except Exception as e:
                 errors.append(e)

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,17 +1,35 @@
 """
-Tests covering the base translation provider architecture and 
-basic registry functionality for susi_translator.
+tests covering the translation provider architecture, 
+ensuring the abstract interface and double-checked locking behave as expected
 """
 
 from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
 import pytest
 
-from providers.base import TranslationProvider, TranslationError
-from providers.registry import ProviderRegistry
+from providers.base import TranslationProvider, TranslationError, ProviderConfigError
+from providers.registry import (
+    ProviderRegistry,
+    register_provider,
+    available_providers,
+)
 
-#concrete providers
+#concrete providers used in tests
 class EchoProvider(TranslationProvider):
-    """Returns the input text unchanged."""
+    """Returns the input text unchanged. Tracks instantiation count."""
+
+    instantiation_count = 0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Enforces threads to collide in the concurrency test
+        # to guarantee the double-checked lock is actually tested
+        time.sleep(0.05) 
+        EchoProvider.instantiation_count += 1
+
     def translate(self, text, source_lang, target_lang, **kwargs):
         return text
 
@@ -22,20 +40,36 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
-class UnavailableProvider(TranslationProvider):
-    """Always reports itself as unavailable."""
+class FailingProvider(TranslationProvider):
+    """Raises TranslationError on every translate() call."""
     def translate(self, text, source_lang, target_lang, **kwargs):
-        raise TranslationError("This provider is unavailable")
+        raise TranslationError("intentional failure")
 
     def is_available(self):
-        return False
+        return True
 
     @property
     def provider_name(self):
-        return "unavailable"
+        return "failing"
 
+class ConfigCapturingProvider(TranslationProvider):
+    """Stores the config it receives so tests can assert on it."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.received_config = dict(self.config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "config_capturing"
+    
 class KwargsCapturingProvider(TranslationProvider):
-    """Stores the kwargs passed to translate() so tests can assert on them."""
+    """Stores the kwargs passed to translate() so tests can assert on them"""
     def __init__(self, config=None):
         super().__init__(config)
         self.last_kwargs = {}
@@ -52,8 +86,19 @@ class KwargsCapturingProvider(TranslationProvider):
         return "kwargs_capturing"
 
 
-#Abstract interfaces
+#Fixtures
 
+@pytest.fixture(autouse=True)
+def clean_factories():
+    with patch("providers.registry._PROVIDER_FACTORIES", {}) as mock_dict:
+        yield mock_dict
+
+@pytest.fixture
+def registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+#Abstract interface test
 class TestAbstractInterface:
     def test_cannot_instantiate_abstract_class(self) -> None:
         with pytest.raises(TypeError):
@@ -75,42 +120,103 @@ class TestAbstractInterface:
         assert provider.config["api_key"] == "secret"
 
 
-#Registry Tests
+#Registration & Configuration tests
+class TestProviderRegistration:
+    def test_register_and_list(self) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        assert "echo" in available_providers()
 
-class TestBasicRegistry:
-    def test_register_and_retrieve(self):
-        registry = ProviderRegistry()
-        provider = EchoProvider()
+class TestRegistryConfigure:
+    def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        registry.configure("config_capturing", api_key="secret-key")
         
-        registry.register(provider)
-        retrieved = registry.get_provider("echo")
-        
-        assert retrieved is provider
+        registry.translate("config_capturing", "hello", "en", "de")
+        instance = registry._providers["config_capturing"]["instance"]
+        assert instance.received_config["api_key"] == "secret-key"
 
-    def test_unregistered_provider_raises_error(self):
-        registry = ProviderRegistry()
-        with pytest.raises(ValueError, match="is not registered"):
-            registry.get_provider("missing")
 
-    def test_translate_routes_correctly(self):
-        registry = ProviderRegistry()
-        registry.register(EchoProvider())
+#Lazy instantiation tests
+class TestLazyInstantiation:
+    def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
         
-        result = registry.translate("echo", "hello", "en", "es")
-        assert result == "hello"
+        # Instance should be None before translation
+        assert registry._providers["echo"]["instance"] is None
+        
+        registry.translate("echo", "hello", "en", "de")
+        
+        # Instance should exist after translation
+        assert registry._providers["echo"]["instance"] is not None
 
-    def test_translate_checks_availability(self):
-        registry = ProviderRegistry()
-        registry.register(UnavailableProvider())
-        
-        # It should check `is_available()` and throw an error before trying to translate
-        with pytest.raises(RuntimeError, match="currently unavailable"):
-            registry.translate("unavailable", "hello", "en", "es")
 
-    def test_translate_forwards_kwargs(self):
-        registry = ProviderRegistry()
-        provider = KwargsCapturingProvider()
-        registry.register(provider)
+#Translation tests
+class TestTranslate:
+    def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
+        """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
+        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
+        registry.configure("kwargs_capturing")
         
-        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
-        assert provider.last_kwargs == {"temperature": 0.7}
+        registry.translate(
+            "kwargs_capturing", 
+            "hello", 
+            "en", 
+            "de", 
+            temperature=0.3, 
+            formality="informal"
+        )
+        
+        instance = registry._providers["kwargs_capturing"]["instance"]
+        assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
+
+    def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
+        """Ensure runtime TranslationErrors from the provider are properly propagated."""
+        register_provider("failing", lambda config: FailingProvider(config))
+        registry.configure("failing")
+        
+        with pytest.raises(TranslationError, match="intentional failure"):
+            registry.translate("failing", "hello", "en", "de")
+
+    def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
+        """Ensure errors during lazy initialization are caught and wrapped correctly."""
+        def bad_factory(config):
+            raise RuntimeError("missing heavy ML weights")
+
+        register_provider("broken", bad_factory)
+        registry.configure("broken")
+        
+        with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
+            registry.translate("broken", "hello", "en", "de")
+
+
+# Thread safety test 
+class TestThreadSafety:
+    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating simultaneously must not bypass the lock."""
+        EchoProvider.instantiation_count = 0
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                # All 20 threads will smash into the lock simultaneously here.
+                result = registry.translate("echo", "hello", "en", "de")
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert all(r == "hello" for r in results)
+        
+        # PROOF: Even with 20 threads colliding, the model was only loaded into RAM exactly once.
+        assert EchoProvider.instantiation_count == 1

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,116 @@
+"""
+Tests covering the base translation provider architecture and 
+basic registry functionality for susi_translator.
+"""
+
+from __future__ import annotations
+import pytest
+
+from providers.base import TranslationProvider, TranslationError
+from providers.registry import ProviderRegistry
+
+#concrete providers
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
+
+
+#Abstract interfaces
+
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+#Registry Tests
+
+class TestBasicRegistry:
+    def test_register_and_retrieve(self):
+        registry = ProviderRegistry()
+        provider = EchoProvider()
+        
+        registry.register(provider)
+        retrieved = registry.get_provider("echo")
+        
+        assert retrieved is provider
+
+    def test_unregistered_provider_raises_error(self):
+        registry = ProviderRegistry()
+        with pytest.raises(ValueError, match="is not registered"):
+            registry.get_provider("missing")
+
+    def test_translate_routes_correctly(self):
+        registry = ProviderRegistry()
+        registry.register(EchoProvider())
+        
+        result = registry.translate("echo", "hello", "en", "es")
+        assert result == "hello"
+
+    def test_translate_checks_availability(self):
+        registry = ProviderRegistry()
+        registry.register(UnavailableProvider())
+        
+        # It should check `is_available()` and throw an error before trying to translate
+        with pytest.raises(RuntimeError, match="currently unavailable"):
+            registry.translate("unavailable", "hello", "en", "es")
+
+    def test_translate_forwards_kwargs(self):
+        registry = ProviderRegistry()
+        provider = KwargsCapturingProvider()
+        registry.register(provider)
+        
+        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
+        assert provider.last_kwargs == {"temperature": 0.7}


### PR DESCRIPTION
**Note: This is a stacked PR built on top of #61  and #64 . The "Files Changed" tab currently includes commits from the base architecture and lazy-loading factories. The diff will clean up automatically once the previous PRs are merged into main.**

Description:
Fixes #65 

This PR completes the core translation provider architecture by introducing strict multi-tenant isolation. Because the Susi Translator server will handle requests from multiple Eventyay/other platform organizers simultaneously, it is critical that different tenants can configure distinct translation models and API keys or, other attributes without state leakage.

Changes:
- **Tenant-Based Routing:** Refactored the ProviderRegistry internal state from _providers to _tenants, mapping configurations and lazy-loaded instances strictly by tenant_id.
- **Method Signatures:** Updated configure() and translate() to require a tenant_id to ensure operations are always scoped to the correct session.
- **Lifecycle Management:** Added remove() to safely clear a tenant's configuration and get_provider_name() for lookup operations.
- **Documentation:** Updated docstrings in base.py to explicitly outline the requirement for isolated, non-shared state across provider instances.

Testing: Introduced TestMultiTenantIsolation to the pytest suite, successfully proving that concurrently running tenants (tenant_a and tenant_b) maintain completely isolated configurations and do not leak API keys.

## Reviewers guide:

This PR completes the core translation provider architecture by introducing strict multi-tenant isolation. Because the Susi Translator server will handle requests from multiple platform organizers simultaneously, it is critical that different tenants can configure distinct translation models and API keys without state leakage. There are no user facing API endpoints in this step.

Since this PR is focused entirely on state isolation, please focus your review on the refactor of the ProviderRegistry's internal state, the updated method signatures enforcing `tenant_id` in `configure()` and `translate()`, and the new lifecycle management methods like `remove()`.

***How to Test***
Because this PR completes the core translation provider architecture by introducing tenant isolation. than user-facing API routes, the verification is entirely handled via the automated unit test suite
- Sync your environment:

```bash
uv sync
```

- Run the provider architecture test file: 
Navigate to the flask/tests directory and execute:
```bash
uv run pytest test_provider_architecture.py
```
<img width="1887" height="221" alt="image" src="https://github.com/user-attachments/assets/b94449dd-4cb6-469a-9234-050094725003" />

***Local tests***:
- i have added an endpoint **locally** for checking the tenant isolation so i verified by getting the memory address of the tenants.

<img width="1918" height="130" alt="multi-tenant-setup" src="https://github.com/user-attachments/assets/661c2c28-8056-4a79-9a3e-e9d55bcdd713" />
 
