### PR TITLE
added /configure endpoint to register translation providers per organizer with dynamic configuration for any models

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,9 +1,11 @@
 from .base import TranslationProvider, TranslationError, ProviderConfigError
-from .registry import ProviderRegistry
+from .registry import ProviderRegistry, register_provider, available_providers
 
 __all__ = [
     "TranslationProvider",
     "TranslationError",
     "ProviderConfigError",
     "ProviderRegistry",
+    "register_provider",
+    "available_providers",
 ]

--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,9 @@
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -24,6 +24,9 @@ class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.
 
+    To ensure fast startup times, heavy model initializations are strictly 
+    deferred until a translation is actually requested, rather than loading at import time.
+    
     The translate method leverages kwargs to remain extensible, allowing you to easily pass 
     provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
     to alter the base signature.
@@ -51,20 +54,20 @@ class TranslationProvider(ABC):
         **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
         'formality' for DeepL).
         """
-        pass
+        ...
 
     @abstractmethod
     def is_available(self) -> bool:
         """
         Check if the provider is healthy and ready to serve requests.
         """
-        pass
+        ...
 
     @property
     @abstractmethod
     def provider_name(self) -> str:
         """
-        The canonical, machine-readable name of the provider,
-        Use in logging, telemetry, and registry lookups.
+        The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
+        Used heavily in logging, telemetry, and registry lookups.
         """
-        pass
+        ...

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -24,18 +24,21 @@ class TranslationProvider(ABC):
     """
     Abstract base class for all translation and LLM providers.
 
-    To ensure fast startup times, heavy model initializations are strictly 
-    deferred until a translation is actually requested, rather than loading at import time.
+    To ensure fast startup time are strictly deferred until a 
+    translation is actually requested, rather than loading at import time.
+
+    We also enforce tenant isolation by making sure each instance holds its own
+    distinct configuration without relying on shared class-level state. 
     
-    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
-    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    the translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings like, an LLM's temperature or DeepL's formality—without ever having 
     to alter the base signature.
     """
 
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         """
-        Initialize the provider with necessary configuration.
-        This can include API keys, model paths, or any other settings required 
+        Initializing the provider with tenant-specific configuration,
+        this can include API keys, model paths, or any other settings required 
         for the provider to function.
         """
         # Create a shallow copy to prevent accidental mutation of the original dict
@@ -50,16 +53,17 @@ class TranslationProvider(ABC):
         **kwargs: Any
     ) -> str:
         """
-        Translate text from source_lang to target_lang.
-        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
-        'formality' for DeepL).
+        Translate text from source_lang to target_lang
+        **kwargs: Optional provider specific parameters('temperature' for LLMs, 
+        'formality' for DeepL)
         """
         ...
 
+    #health check to ensure provider is ready to serve requests
     @abstractmethod
     def is_available(self) -> bool:
         """
-        Check if the provider is healthy and ready to serve requests.
+        Check if the provider is healthy and ready to serve requests
         """
         ...
 
@@ -68,6 +72,6 @@ class TranslationProvider(ABC):
     def provider_name(self) -> str:
         """
         The canonical, machine-readable name of the provider (e.g., 'nllb', 'deepl', 'openai').
-        Used heavily in logging, telemetry, and registry lookups.
+        Used heavily in logging, telemetry, and registry lookups
         """
         ...

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,70 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(Exception):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class TranslationProvider(ABC):
+    """
+    Abstract base class for all translation and LLM providers.
+
+    The translate method leverages kwargs to remain extensible, allowing you to easily pass 
+    provider-specific settings—like an LLM's temperature or DeepL's formality—without ever having 
+    to alter the base signature.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """
+        Initialize the provider with necessary configuration.
+        This can include API keys, model paths, or any other settings required 
+        for the provider to function.
+        """
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translate text from source_lang to target_lang.
+        **kwargs: Optional provider-specific parameters ('temperature' for LLMs, 
+        'formality' for DeepL).
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the provider is healthy and ready to serve requests.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        """
+        The canonical, machine-readable name of the provider,
+        Use in logging, telemetry, and registry lookups.
+        """
+        pass

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,6 +1,7 @@
 """
-provider registry for Translator.
-This module manages the deferred instantiation of translation providers
+Per-tenant provider registry for Susi Translator,
+This module manages the lifecycle of translation 
+providers
 """
 
 from __future__ import annotations
@@ -13,7 +14,8 @@ from .base import TranslationProvider, TranslationError, ProviderConfigError
 
 logger = logging.getLogger(__name__)
 
-# Registry of provider factories
+# Registry of provider factories. Each factory is a callable that takes a config dict
+# and returns a TranslationProvider instance
 _PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
 
 
@@ -21,9 +23,11 @@ def register_provider(
     name: str, 
     factory: Callable[[Dict[str, Any]], TranslationProvider]
 ) -> None:
-    """Register a provider factory under a canonical name"""
+    """
+    Register a provider factory under a canonical name
+    """
     _PROVIDER_FACTORIES[name] = factory
-    logger.debug(f"Registered translation provider factory: {name}")
+    logger.debug(f"Registered translation provider: {name}")
 
 
 def available_providers() -> List[str]:
@@ -33,22 +37,24 @@ def available_providers() -> List[str]:
 
 class ProviderRegistry:
     """
-    A registry that defers translation provider instantiation until first use
-    to minimize startup time and memory footprint.
+    Per-tenant provider registry. One shared instance should be created
+    at module load time in transcribe_server.py and used across all requests
     """
+
     def __init__(self):
-        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
-        self._providers: Dict[str, Dict[str, Any]] = {}
+        # tenant_id -> { "provider_name": str, "config": dict, "instance": Optional[TranslationProvider] }
+        self._tenants: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
 
     def configure(
         self,
+        tenant_id: str,
         provider_name: str,
         api_key: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """
-        Configure a provider's settings before instantiation.
+        Configure a provider for a tenant session.
         """
         if provider_name not in _PROVIDER_FACTORIES:
             raise ValueError(
@@ -58,41 +64,47 @@ class ProviderRegistry:
 
         # Bundle the config as expected by base.py
         config_dict = {"api_key": api_key, **kwargs}
-        
+
         with self._lock:
-            self._providers[provider_name] = {
+            self._tenants[tenant_id] = {
+                "provider_name": provider_name,
                 "config": config_dict,
-                "instance": None,  # Instantiated lazily on first use
+                "instance": None,  # instantiated lazily on first use
             }
             
-        logger.info(f"Configured lazy provider '{provider_name}'")
+        logger.info(
+            f"Configured provider '{provider_name}' for tenant '{tenant_id}'"
+        )
 
     def translate(
         self,
-        provider_name: str,
+        tenant_id: str,
         text: str,
         source_lang: str,
         target_lang: str,
         **kwargs: Any
-    ) -> str:
+    ) -> Optional[str]:
         """
-        Translates text, lazily instantiating the provider if necessary.
+        Translate text for a given tenant using their configured provider.
         """
-        entry = self._providers.get(provider_name)
-        
+        #Fast, lock-free read to get the tenant entry
+        entry = self._tenants.get(tenant_id)
         if entry is None:
-            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+            return None  # no translation configured for this tenant
 
-        # Lazy Instantiation with Double-Checked Locking
+        #Lazy Instantiation with Double-Checked Locking
         if entry["instance"] is None:
             with self._lock:
-                # Check again inside the lock to prevent a race condition
+                
                 if entry["instance"] is None:
+                    provider_name = entry["provider_name"]
                     factory = _PROVIDER_FACTORIES[provider_name]
+                    
                     try:
+                        # Pass the bundled config dict to match base.py
                         instance = factory(entry["config"])
                         entry["instance"] = instance
-                        logger.info(f"Lazily instantiated '{provider_name}'")
+                        logger.info(f"Lazily instantiated '{provider_name}' for tenant '{tenant_id}'")
                     except Exception as e:
                         logger.error(f"Failed to instantiate '{provider_name}': {e}")
                         raise ProviderConfigError(f"Provider initialization failed: {e}")
@@ -100,7 +112,22 @@ class ProviderRegistry:
         provider: TranslationProvider = entry["instance"]
 
         if not provider.is_available():
-            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            logger.warning(
+                f"Provider '{provider.provider_name}' is not available "
+                f"for tenant '{tenant_id}'"
+            )
+            return None
 
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)
+
+    def remove(self, tenant_id: str) -> None:
+        """Remove provider config for a tenant"""
+        with self._lock:
+            self._tenants.pop(tenant_id, None)
+
+    def get_provider_name(self, tenant_id: str) -> Optional[str]:
+        """Return the configured provider name for a tenant, or None."""
+        with self._lock:
+            entry = self._tenants.get(tenant_id)
+            return entry["provider_name"] if entry else None

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,55 +1,106 @@
 """
-Basic provider registry for Translator,
-This manages the registration and retrieval of translation providers
+provider registry for Translator.
+This module manages the deferred instantiation of translation providers
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+import threading
+from typing import Any, Callable, Dict, List, Optional
 
-from .base import TranslationProvider, TranslationError
+from .base import TranslationProvider, TranslationError, ProviderConfigError
 
 logger = logging.getLogger(__name__)
 
+# Registry of provider factories
+_PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
+
+
+def register_provider(
+    name: str, 
+    factory: Callable[[Dict[str, Any]], TranslationProvider]
+) -> None:
+    """Register a provider factory under a canonical name"""
+    _PROVIDER_FACTORIES[name] = factory
+    logger.debug(f"Registered translation provider factory: {name}")
+
+
+def available_providers() -> List[str]:
+    """Return list of all registered provider names"""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
 class ProviderRegistry:
     """
-    A simple registry to hold instantiated translation providers.
+    A registry that defers translation provider instantiation until first use
+    to minimize startup time and memory footprint.
     """
-
     def __init__(self):
-        self._providers: Dict[str, TranslationProvider] = {}
+        # Maps provider_name -> { "config": dict, "instance": Optional[TranslationProvider] }
+        self._providers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
 
-    def register(self, provider: TranslationProvider) -> None:
+    def configure(
+        self,
+        provider_name: str,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
         """
-        Registers an already-instantiated translation provider
+        Configure a provider's settings before instantiation.
         """
-        self._providers[provider.provider_name] = provider
-        logger.info(f"Registered translation provider: {provider.provider_name}")
+        if provider_name not in _PROVIDER_FACTORIES:
+            raise ValueError(
+                f"Unknown provider '{provider_name}'. "
+                f"Available: {available_providers()}"
+            )
 
-    def get_provider(self, provider_name: str) -> TranslationProvider:
-        """
-        Retrieves a provider by name, Raises ValueError if the provider is not registered.
-        """
-        if provider_name not in self._providers:
-            raise ValueError(f"Provider '{provider_name}' is not registered.")
-        return self._providers[provider_name]
+        # Bundle the config as expected by base.py
+        config_dict = {"api_key": api_key, **kwargs}
+        
+        with self._lock:
+            self._providers[provider_name] = {
+                "config": config_dict,
+                "instance": None,  # Instantiated lazily on first use
+            }
+            
+        logger.info(f"Configured lazy provider '{provider_name}'")
 
     def translate(
-        self, 
-        provider_name: str, 
-        text: str, 
-        source_lang: str, 
-        target_lang: str, 
+        self,
+        provider_name: str,
+        text: str,
+        source_lang: str,
+        target_lang: str,
         **kwargs: Any
     ) -> str:
         """
-        Translates text using the specified provider
+        Translates text, lazily instantiating the provider if necessary.
         """
-        provider = self.get_provider(provider_name)
+        entry = self._providers.get(provider_name)
         
+        if entry is None:
+            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+
+        # Lazy Instantiation with Double-Checked Locking
+        if entry["instance"] is None:
+            with self._lock:
+                # Check again inside the lock to prevent a race condition
+                if entry["instance"] is None:
+                    factory = _PROVIDER_FACTORIES[provider_name]
+                    try:
+                        instance = factory(entry["config"])
+                        entry["instance"] = instance
+                        logger.info(f"Lazily instantiated '{provider_name}'")
+                    except Exception as e:
+                        logger.error(f"Failed to instantiate '{provider_name}': {e}")
+                        raise ProviderConfigError(f"Provider initialization failed: {e}")
+
+        provider: TranslationProvider = entry["instance"]
+
         if not provider.is_available():
             raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
-            
+
         # Pass the extra kwargs down to support provider-specific settings
         return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,55 @@
+"""
+Basic provider registry for Translator,
+This manages the registration and retrieval of translation providers
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .base import TranslationProvider, TranslationError
+
+logger = logging.getLogger(__name__)
+
+class ProviderRegistry:
+    """
+    A simple registry to hold instantiated translation providers.
+    """
+
+    def __init__(self):
+        self._providers: Dict[str, TranslationProvider] = {}
+
+    def register(self, provider: TranslationProvider) -> None:
+        """
+        Registers an already-instantiated translation provider
+        """
+        self._providers[provider.provider_name] = provider
+        logger.info(f"Registered translation provider: {provider.provider_name}")
+
+    def get_provider(self, provider_name: str) -> TranslationProvider:
+        """
+        Retrieves a provider by name, Raises ValueError if the provider is not registered.
+        """
+        if provider_name not in self._providers:
+            raise ValueError(f"Provider '{provider_name}' is not registered.")
+        return self._providers[provider_name]
+
+    def translate(
+        self, 
+        provider_name: str, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+        """
+        Translates text using the specified provider
+        """
+        provider = self.get_provider(provider_name)
+        
+        if not provider.is_available():
+            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+            
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,6 +1,7 @@
 """
-tests covering the translation provider architecture, 
-ensuring the abstract interface and double-checked locking behave as expected
+Tests covers the translation provider architecture, ensuring that the 
+abstract interface is correctly defined and that the provider registry 
+behaves as expected
 """
 
 from __future__ import annotations
@@ -17,7 +18,8 @@ from providers.registry import (
     available_providers,
 )
 
-#concrete providers used in tests
+# Minimal concrete providers for testing 
+
 class EchoProvider(TranslationProvider):
     """Returns the input text unchanged. Tracks instantiation count."""
 
@@ -25,7 +27,7 @@ class EchoProvider(TranslationProvider):
 
     def __init__(self, config=None):
         super().__init__(config)
-        # Enforces threads to collide in the concurrency test
+        # enforces threads to collide in the concurrency test
         # to guarantee the double-checked lock is actually tested
         time.sleep(0.05) 
         EchoProvider.instantiation_count += 1
@@ -40,8 +42,26 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
 class FailingProvider(TranslationProvider):
     """Raises TranslationError on every translate() call."""
+    def __init__(self, config=None):
+        super().__init__(config)
+
     def translate(self, text, source_lang, target_lang, **kwargs):
         raise TranslationError("intentional failure")
 
@@ -68,6 +88,7 @@ class ConfigCapturingProvider(TranslationProvider):
     def provider_name(self):
         return "config_capturing"
     
+
 class KwargsCapturingProvider(TranslationProvider):
     """Stores the kwargs passed to translate() so tests can assert on them"""
     def __init__(self, config=None):
@@ -86,6 +107,7 @@ class KwargsCapturingProvider(TranslationProvider):
         return "kwargs_capturing"
 
 
+
 #Fixtures
 
 @pytest.fixture(autouse=True)
@@ -98,7 +120,7 @@ def registry() -> ProviderRegistry:
     return ProviderRegistry()
 
 
-#Abstract interface test
+#Abstract interface tests
 class TestAbstractInterface:
     def test_cannot_instantiate_abstract_class(self) -> None:
         with pytest.raises(TypeError):
@@ -120,46 +142,55 @@ class TestAbstractInterface:
         assert provider.config["api_key"] == "secret"
 
 
-#Registration & Configuration tests
+
+#Registration tests
 class TestProviderRegistration:
     def test_register_and_list(self) -> None:
         register_provider("echo", lambda config: EchoProvider(config))
         assert "echo" in available_providers()
 
+
+
+#Registry configuration tests
 class TestRegistryConfigure:
     def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
         register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
-        registry.configure("config_capturing", api_key="secret-key")
+        registry.configure("tenant1", "config_capturing", api_key="secret-key")
         
-        registry.translate("config_capturing", "hello", "en", "de")
-        instance = registry._providers["config_capturing"]["instance"]
+        registry.translate("tenant1", "hello", "en", "de")
+        instance = registry._tenants["tenant1"]["instance"]
         assert instance.received_config["api_key"] == "secret-key"
 
 
 #Lazy instantiation tests
+
 class TestLazyInstantiation:
     def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
         register_provider("echo", lambda config: EchoProvider(config))
-        registry.configure("echo")
+        registry.configure("tenant1", "echo")
         
         # Instance should be None before translation
-        assert registry._providers["echo"]["instance"] is None
+        assert registry._tenants["tenant1"]["instance"] is None
         
-        registry.translate("echo", "hello", "en", "de")
+        registry.translate("tenant1", "hello", "en", "de")
         
         # Instance should exist after translation
-        assert registry._providers["echo"]["instance"] is not None
+        assert registry._tenants["tenant1"]["instance"] is not None
 
 
-#Translation tests
+
+# Translation tests
 class TestTranslate:
     def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
         """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
-        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
-        registry.configure("kwargs_capturing")
+        register_provider(
+            "kwargs_capturing", 
+            lambda config: KwargsCapturingProvider(config)
+        )
+        registry.configure("tenant1", "kwargs_capturing")
         
         registry.translate(
-            "kwargs_capturing", 
+            "tenant1", 
             "hello", 
             "en", 
             "de", 
@@ -167,16 +198,17 @@ class TestTranslate:
             formality="informal"
         )
         
-        instance = registry._providers["kwargs_capturing"]["instance"]
+        instance = registry._tenants["tenant1"]["instance"]
         assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
 
     def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
         """Ensure runtime TranslationErrors from the provider are properly propagated."""
         register_provider("failing", lambda config: FailingProvider(config))
-        registry.configure("failing")
+        registry.configure("tenant1", "failing")
         
+        # The provider is designed to fail when translate is called
         with pytest.raises(TranslationError, match="intentional failure"):
-            registry.translate("failing", "hello", "en", "de")
+            registry.translate("tenant1", "hello", "en", "de")
 
     def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
         """Ensure errors during lazy initialization are caught and wrapped correctly."""
@@ -184,27 +216,51 @@ class TestTranslate:
             raise RuntimeError("missing heavy ML weights")
 
         register_provider("broken", bad_factory)
-        registry.configure("broken")
+        registry.configure("tenant1", "broken")
         
+        # The initialization happens lazily during the first translate call.
+        # It should catch the RuntimeError and wrap it in a ProviderConfigError.
         with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
-            registry.translate("broken", "hello", "en", "de")
+            registry.translate("tenant1", "hello", "en", "de")
 
 
-# Thread safety test 
+# Translation & Multi-tenant tests
+
+class TestMultiTenantIsolation:
+    def test_tenant_config_is_isolated(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        
+        registry.configure("tenant_a", "config_capturing", api_key="key-a")
+        registry.configure("tenant_b", "config_capturing", api_key="key-b")
+
+        registry.translate("tenant_a", "x", "en", "de")
+        registry.translate("tenant_b", "x", "en", "de")
+
+        instance_a = registry._tenants["tenant_a"]["instance"]
+        instance_b = registry._tenants["tenant_b"]["instance"]
+
+        assert instance_a.received_config["api_key"] == "key-a"
+        assert instance_b.received_config["api_key"] == "key-b"
+        assert instance_a is not instance_b
+
+
+
+# Thread safety test
 class TestThreadSafety:
-    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
-        """Multiple threads translating simultaneously must not bypass the lock."""
+    def test_concurrent_translate_same_tenant(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating for the same tenant must not bypass the lock."""
         EchoProvider.instantiation_count = 0
         register_provider("echo", lambda config: EchoProvider(config))
-        registry.configure("echo")
+        registry.configure("tenant1", "echo")
 
         results = []
         errors = []
 
         def worker():
             try:
-                # All 20 threads will smash into the lock simultaneously here.
-                result = registry.translate("echo", "hello", "en", "de")
+                # Due to the time.sleep in EchoProvider, all 20 threads will 
+                # smash into the lock simultaneously here.
+                result = registry.translate("tenant1", "hello", "en", "de")
                 results.append(result)
             except Exception as e:
                 errors.append(e)

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,17 +1,35 @@
 """
-Tests covering the base translation provider architecture and 
-basic registry functionality for susi_translator.
+tests covering the translation provider architecture, 
+ensuring the abstract interface and double-checked locking behave as expected
 """
 
 from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
 import pytest
 
-from providers.base import TranslationProvider, TranslationError
-from providers.registry import ProviderRegistry
+from providers.base import TranslationProvider, TranslationError, ProviderConfigError
+from providers.registry import (
+    ProviderRegistry,
+    register_provider,
+    available_providers,
+)
 
-#concrete providers
+#concrete providers used in tests
 class EchoProvider(TranslationProvider):
-    """Returns the input text unchanged."""
+    """Returns the input text unchanged. Tracks instantiation count."""
+
+    instantiation_count = 0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Enforces threads to collide in the concurrency test
+        # to guarantee the double-checked lock is actually tested
+        time.sleep(0.05) 
+        EchoProvider.instantiation_count += 1
+
     def translate(self, text, source_lang, target_lang, **kwargs):
         return text
 
@@ -22,20 +40,36 @@ class EchoProvider(TranslationProvider):
     def provider_name(self):
         return "echo"
 
-class UnavailableProvider(TranslationProvider):
-    """Always reports itself as unavailable."""
+class FailingProvider(TranslationProvider):
+    """Raises TranslationError on every translate() call."""
     def translate(self, text, source_lang, target_lang, **kwargs):
-        raise TranslationError("This provider is unavailable")
+        raise TranslationError("intentional failure")
 
     def is_available(self):
-        return False
+        return True
 
     @property
     def provider_name(self):
-        return "unavailable"
+        return "failing"
 
+class ConfigCapturingProvider(TranslationProvider):
+    """Stores the config it receives so tests can assert on it."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.received_config = dict(self.config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "config_capturing"
+    
 class KwargsCapturingProvider(TranslationProvider):
-    """Stores the kwargs passed to translate() so tests can assert on them."""
+    """Stores the kwargs passed to translate() so tests can assert on them"""
     def __init__(self, config=None):
         super().__init__(config)
         self.last_kwargs = {}
@@ -52,8 +86,19 @@ class KwargsCapturingProvider(TranslationProvider):
         return "kwargs_capturing"
 
 
-#Abstract interfaces
+#Fixtures
 
+@pytest.fixture(autouse=True)
+def clean_factories():
+    with patch("providers.registry._PROVIDER_FACTORIES", {}) as mock_dict:
+        yield mock_dict
+
+@pytest.fixture
+def registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+#Abstract interface test
 class TestAbstractInterface:
     def test_cannot_instantiate_abstract_class(self) -> None:
         with pytest.raises(TypeError):
@@ -75,42 +120,103 @@ class TestAbstractInterface:
         assert provider.config["api_key"] == "secret"
 
 
-#Registry Tests
+#Registration & Configuration tests
+class TestProviderRegistration:
+    def test_register_and_list(self) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        assert "echo" in available_providers()
 
-class TestBasicRegistry:
-    def test_register_and_retrieve(self):
-        registry = ProviderRegistry()
-        provider = EchoProvider()
+class TestRegistryConfigure:
+    def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        registry.configure("config_capturing", api_key="secret-key")
         
-        registry.register(provider)
-        retrieved = registry.get_provider("echo")
-        
-        assert retrieved is provider
+        registry.translate("config_capturing", "hello", "en", "de")
+        instance = registry._providers["config_capturing"]["instance"]
+        assert instance.received_config["api_key"] == "secret-key"
 
-    def test_unregistered_provider_raises_error(self):
-        registry = ProviderRegistry()
-        with pytest.raises(ValueError, match="is not registered"):
-            registry.get_provider("missing")
 
-    def test_translate_routes_correctly(self):
-        registry = ProviderRegistry()
-        registry.register(EchoProvider())
+#Lazy instantiation tests
+class TestLazyInstantiation:
+    def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
         
-        result = registry.translate("echo", "hello", "en", "es")
-        assert result == "hello"
+        # Instance should be None before translation
+        assert registry._providers["echo"]["instance"] is None
+        
+        registry.translate("echo", "hello", "en", "de")
+        
+        # Instance should exist after translation
+        assert registry._providers["echo"]["instance"] is not None
 
-    def test_translate_checks_availability(self):
-        registry = ProviderRegistry()
-        registry.register(UnavailableProvider())
-        
-        # It should check `is_available()` and throw an error before trying to translate
-        with pytest.raises(RuntimeError, match="currently unavailable"):
-            registry.translate("unavailable", "hello", "en", "es")
 
-    def test_translate_forwards_kwargs(self):
-        registry = ProviderRegistry()
-        provider = KwargsCapturingProvider()
-        registry.register(provider)
+#Translation tests
+class TestTranslate:
+    def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
+        """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
+        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
+        registry.configure("kwargs_capturing")
         
-        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
-        assert provider.last_kwargs == {"temperature": 0.7}
+        registry.translate(
+            "kwargs_capturing", 
+            "hello", 
+            "en", 
+            "de", 
+            temperature=0.3, 
+            formality="informal"
+        )
+        
+        instance = registry._providers["kwargs_capturing"]["instance"]
+        assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
+
+    def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
+        """Ensure runtime TranslationErrors from the provider are properly propagated."""
+        register_provider("failing", lambda config: FailingProvider(config))
+        registry.configure("failing")
+        
+        with pytest.raises(TranslationError, match="intentional failure"):
+            registry.translate("failing", "hello", "en", "de")
+
+    def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
+        """Ensure errors during lazy initialization are caught and wrapped correctly."""
+        def bad_factory(config):
+            raise RuntimeError("missing heavy ML weights")
+
+        register_provider("broken", bad_factory)
+        registry.configure("broken")
+        
+        with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
+            registry.translate("broken", "hello", "en", "de")
+
+
+# Thread safety test 
+class TestThreadSafety:
+    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating simultaneously must not bypass the lock."""
+        EchoProvider.instantiation_count = 0
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                # All 20 threads will smash into the lock simultaneously here.
+                result = registry.translate("echo", "hello", "en", "de")
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert all(r == "hello" for r in results)
+        
+        # PROOF: Even with 20 threads colliding, the model was only loaded into RAM exactly once.
+        assert EchoProvider.instantiation_count == 1

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,116 @@
+"""
+Tests covering the base translation provider architecture and 
+basic registry functionality for susi_translator.
+"""
+
+from __future__ import annotations
+import pytest
+
+from providers.base import TranslationProvider, TranslationError
+from providers.registry import ProviderRegistry
+
+#concrete providers
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class UnavailableProvider(TranslationProvider):
+    """Always reports itself as unavailable."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("This provider is unavailable")
+
+    def is_available(self):
+        return False
+
+    @property
+    def provider_name(self):
+        return "unavailable"
+
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
+
+
+#Abstract interfaces
+
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+#Registry Tests
+
+class TestBasicRegistry:
+    def test_register_and_retrieve(self):
+        registry = ProviderRegistry()
+        provider = EchoProvider()
+        
+        registry.register(provider)
+        retrieved = registry.get_provider("echo")
+        
+        assert retrieved is provider
+
+    def test_unregistered_provider_raises_error(self):
+        registry = ProviderRegistry()
+        with pytest.raises(ValueError, match="is not registered"):
+            registry.get_provider("missing")
+
+    def test_translate_routes_correctly(self):
+        registry = ProviderRegistry()
+        registry.register(EchoProvider())
+        
+        result = registry.translate("echo", "hello", "en", "es")
+        assert result == "hello"
+
+    def test_translate_checks_availability(self):
+        registry = ProviderRegistry()
+        registry.register(UnavailableProvider())
+        
+        # It should check `is_available()` and throw an error before trying to translate
+        with pytest.raises(RuntimeError, match="currently unavailable"):
+            registry.translate("unavailable", "hello", "en", "es")
+
+    def test_translate_forwards_kwargs(self):
+        registry = ProviderRegistry()
+        provider = KwargsCapturingProvider()
+        registry.register(provider)
+        
+        registry.translate("kwargs_capturing", "hello", "en", "es", temperature=0.7)
+        assert provider.last_kwargs == {"temperature": 0.7}

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -20,6 +20,13 @@ from dotenv import load_dotenv
 # (and test runs) that delegate to a remote whisper.cpp server, where those
 # heavy deps are not installed.
 
+
+
+#providers.registry contains the ProviderRegistry class and the global registry of providers
+from providers.registry import ProviderRegistry
+
+
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -119,6 +126,12 @@ else:
 # ---------------------------------------------------------------------------
 # Shared in-memory state
 # ---------------------------------------------------------------------------
+# right now is designed for simplicity and low operational overhead, 
+# not for massive scale or multi-instance deployments, so we keep all state in-memory
+# future we can migrate to a more robust storage layer (e.g. Redis) if needed,
+# but the current design is sufficient for our use case and keeps the architecture simple
+registry = ProviderRegistry()
+
 
 # transcripts:  tenant_id -> { chunk_id -> {'transcript': str} }
 transcriptd = {}
@@ -503,6 +516,20 @@ def merge_and_split_transcripts(transcripts):
 # Swagger / flask-restx models
 # ---------------------------------------------------------------------------
 
+# this model is used for the /configure endpoint, which allows clients to set up 
+# their preferred translation provider and its configuration for their session
+
+configure_input_model = api.model('ConfigureRequest', {
+    'tenant_id': fields.String(required=True, description='Tenant ID for the session'),
+    'provider_name': fields.String(required=True, description='Canonical name of the provider (deepl, whisper, openai)'),
+    'config': fields.Raw(required=False, description='Dictionary of provider-specific settings (api_key, model_size)')
+})
+
+configure_response_model = api.model('ConfigureResponse', {
+    'status': fields.String(description='Success or error status'),
+    'message': fields.String(description='Status details')
+})
+
 # NOTE: api.model() registrations must use unique names. The original code
 # used 'Transcript' for both the /transcribe ack and the transcript-payload
 # schema, which made flask-restx silently overwrite the first registration
@@ -545,6 +572,54 @@ session_response_model = api.model('SessionResponse', {
     'source': fields.String(description='Source name this session is registered under'),
 })
 
+
+@api.route('/api/v1/translate/configure')
+class ConfigureProvider(Resource):
+    @api.expect(configure_input_model)
+    @api.response(200, 'Success', configure_response_model)
+    @api.response(400, 'Validation Error')
+    def post(self):
+        '''
+        Configure a translation or transcription provider for a specific tenant session.
+        This isolates provider settings per organizer
+        '''
+        try:
+            data = request.get_json(force=True, silent=True)
+            if not data:
+                return {"status": "error", "message": "No JSON payload received"}, 400
+            
+            tenant_id = data.get("tenant_id")
+            provider_name = data.get("provider_name")
+            config_dict = data.get("config") or {}
+
+            if not tenant_id or not provider_name:
+                return {"status": "error", "message": "Missing required fields: tenant_id and provider_name"}, 400
+            
+            # Extract api_key explicitly, pass the rest dynamically as kwargs
+            api_key = config_dict.pop("api_key", None)
+
+            # Feed it into the registry lock
+            registry.configure(
+                tenant_id=tenant_id,
+                provider_name=provider_name,
+                api_key=api_key,
+                **config_dict
+            )
+            
+           
+            logger.info(f"Locked config for '{tenant_id}' Provider: '{provider_name}' Settings caught: {config_dict}")
+
+            return {
+                "status": "success", 
+                "message": f"Configured '{provider_name}' for tenant '{tenant_id}'"
+            }, 200
+
+        except ValueError as e:
+            # Catches strict base validation errors from the registry
+            return {"status": "error", "message": str(e)}, 400
+        except Exception as e:
+            logger.error("Error in /configure", exc_info=True)
+            return {"status": "error", "message": "Internal server error"}, 500       
 
 @api.route('/session')
 class Session(Resource):

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -585,12 +585,18 @@ class ConfigureProvider(Resource):
         '''
         try:
             data = request.get_json(force=True, silent=True)
-            if not data:
-                return {"status": "error", "message": "No JSON payload received"}, 400
+
+            if data is None:
+                return {"status": "error", "message": "Invalid or missing JSON payload"}, 400
             
             tenant_id = data.get("tenant_id")
             provider_name = data.get("provider_name")
-            config_dict = data.get("config") or {}
+            config_dict = data.get("config")
+
+            if config_dict is None:
+                config_dict = {}
+            elif not isinstance(config_dict, dict):
+                return {"status": "error", "message": "'config' field must be a JSON object"}, 400
 
             if not tenant_id or not provider_name:
                 return {"status": "error", "message": "Missing required fields: tenant_id and provider_name"}, 400
@@ -606,8 +612,12 @@ class ConfigureProvider(Resource):
                 **config_dict
             )
             
-           
-            logger.info(f"Locked config for '{tenant_id}' Provider: '{provider_name}' Settings caught: {config_dict}")
+            logger.info(
+                "Locked config for tenant=%r provider=%r config_keys=%s",
+                tenant_id,
+                provider_name,
+                sorted(config_dict.keys()),
+            )
 
             return {
                 "status": "success", 


### PR DESCRIPTION
**NOTE: This PR is stacked on top of PR #66  (Tenant Isolation & Provider Registry). Please review and merge PR #66 before reviewing this one. This PR is kept as a Draft to prevent merge conflicts until the base architecture is merged.**

Dependency on PRs :
- #61 
- #64 
- #66 

Related issue :
- #67 

### Description of this PR
This PR introduces the`/api/v1/translate/configure` endpoint to the transcription server, bridging the gap between the frontend and the ProviderRegistry built in earlier PRs.

Previously, the server relied on global `.env` variables, which prevented multiple organizers from using different API keys or models simultaneously. This PR implements a secure, RESTful configuration pipeline that allows the frontend to dynamically lock in model settings (like API keys, HF tokens, or hardware parameters) per tenant.

- Added `configure_input_model` and `configure_response_model` Swagger documentation
- Implemented POST `/api/v1/translate/configure` to safely extract tenant_id and provider_name
- Utilized `**kwargs` dictionary unpacking to blindly pass provider-specific settings (like temperature, hf_token, or model_size) directly into the registry without hardcoding them into the Flask route.
- Added strict validation to return 400 Bad Request if an unregistered provider is requested

## Reviewers Guide:
This PR bridges the gap between the frontend and the `ProviderRegistry` by introducing the `/api/v1/translate/configure` endpoint in `transcribe_server.py`. Previously, the server relied on global `.env` variables, preventing multiple organizers from using different models simultaneously. This PR implements a secure, RESTful configuration pipeline that allows dynamic lock in of model settings per tenant. 

Please focus your review on the payload extraction, the **kwargs dictionary unpacking used to pass provider specific settings blindly to the registry, the strict 400 Bad Request validation for unregistered providers, and the new Swagger documentation models.

***how to test this PR***

- Start the server inside flask dir. 

```
uv run python transcribe_server.py
```

- Sync your environment:

```bash
uv sync
```

- Run the provider architecture test file: 
Navigate to the flask/tests directory and execute:
```bash
uv run pytest test_provider_architecture.py
```

- **Add this code snippet in bottom of `registry.py` for mock registrations of the models** :
```
# Temporary mock implementations to allow endpoint verification via curl
class _DevMockProvider(TranslationProvider):
    def __init__(self, config: Dict[str, Any]):
        self.config = config
        self._name = "mock"

    def is_available(self) -> bool:
        return True

    def translate(self, text: str, source_lang: str, target_lang: str, **kwargs: Any) -> str:
        return f"[Dev Mock Translation] {text}"

# basic placeholders for manual curl testing
register_provider("mock", lambda cfg: _DevMockProvider(cfg))
register_provider("nllb", lambda cfg: _DevMockProvider(cfg))
register_provider("openai", lambda cfg: _DevMockProvider(cfg))
```

- check the request by configuring the CURL : 
```
curl -X POST http://127.0.0.1:5040/api/v1/translate/configure   -H "Content-Type: application/json"   -d '{
    "tenant_id": "eventyay_hf_demo",
    "provider_name": "openai",   
    "config": {
      "hf_token": "hf_super_secret_token",
      "model_size": "1.3B",
      "device": "cuda"
    }
  }'
```
`provider_name` must be from, `registered_provider`. the config can be changed.


- ***Expected output***:
 
<img width="1515" height="688" alt="Providers" src="https://github.com/user-attachments/assets/ad88d524-8eb2-48c1-97e9-991b50da9a89" />


