### PR TITLE
feat: applied configuration architecture with lazy loading and added a basic configure endpoint for registration testing

### DIFF
--- a/flask/providers/__init__.py
+++ b/flask/providers/__init__.py
@@ -1,0 +1,11 @@
+from .base import TranslationProvider, TranslationError, ProviderConfigError
+from .registry import ProviderRegistry, register_provider, available_providers
+
+__all__ = [
+    "TranslationProvider",
+    "TranslationError",
+    "ProviderConfigError",
+    "ProviderRegistry",
+    "register_provider",
+    "available_providers",
+]

--- a/flask/providers/base.py
+++ b/flask/providers/base.py
@@ -1,0 +1,55 @@
+"""
+Translation and LLM provider architecture for susi_translator
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+# Configure a base logger for the module
+logger = logging.getLogger(__name__)
+
+
+class TranslationError(Exception):
+    """Base exception for all translation related failures"""
+
+
+class ProviderConfigError(TranslationError):
+    """Raised when a provider is initialized with missing or malformed configuration"""
+
+
+class ProviderUnavailableError(TranslationError):
+    """Raised when a provider is registered but currently unavailable"""
+    pass
+
+
+class TranslationProvider(ABC):
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+
+        # Create a shallow copy to prevent accidental mutation of the original dict
+        self.config = dict(config) if config else {}
+
+    @abstractmethod
+    def translate(
+        self, 
+        text: str, 
+        source_lang: str, 
+        target_lang: str, 
+        **kwargs: Any
+    ) -> str:
+       
+        ...
+
+
+    #health check
+    @abstractmethod
+    def is_available(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        ...

--- a/flask/providers/registry.py
+++ b/flask/providers/registry.py
@@ -1,0 +1,100 @@
+"""
+provider registry for Translator
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Optional
+
+from .base import TranslationProvider, ProviderConfigError
+
+logger = logging.getLogger(__name__)
+
+# Registry of provider factories
+_PROVIDER_FACTORIES: Dict[str, Callable[[Dict[str, Any]], TranslationProvider]] = {}
+
+
+def register_provider(
+    name: str, 
+    factory: Callable[[Dict[str, Any]], TranslationProvider]
+) -> None:
+    
+    """Registers a provider factory under a canonical name"""
+    
+    _PROVIDER_FACTORIES[name] = factory
+    logger.debug(f"Registered translation provider factory: {name}")
+
+
+def available_providers() -> List[str]:
+    """Return list of all registered provider names"""
+    return list(_PROVIDER_FACTORIES.keys())
+
+
+class ProviderRegistry:
+
+    def __init__(self):
+        self._providers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def configure(
+        self,
+        provider_name: str,
+        api_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        if provider_name not in _PROVIDER_FACTORIES:
+            raise ValueError(
+                f"Unknown provider '{provider_name}'. "
+                f"Available: {available_providers()}"
+            )
+
+        config_dict = {"api_key": api_key, **kwargs}
+
+        with self._lock:
+            self._providers[provider_name] = {
+                "config": config_dict,
+                "factory": _PROVIDER_FACTORIES[provider_name],
+                "instance": None,
+            }
+
+        logger.info(f"Configured lazy provider '{provider_name}'")
+
+    def translate(
+        self,
+        provider_name: str,
+        text: str,
+        source_lang: str,
+        target_lang: str,
+        **kwargs: Any
+    ) -> str:
+        """
+        lazily instantiating the provider
+        """
+        entry = self._providers.get(provider_name)
+        
+        if entry is None:
+            raise ValueError(f"Provider '{provider_name}' has not been configured.")
+
+        # Lazy Instantiation with Double Checked Locking
+        if entry["instance"] is None:
+            with self._lock:
+                # Check again inside the lock to prevent a race condition
+                if entry["instance"] is None:
+                    factory = entry["factory"]
+                    try:
+                        instance = factory(entry["config"])
+                        entry["instance"] = instance
+                        logger.info(f"Lazily instantiated '{provider_name}'")
+                    except Exception as e:
+                        logger.exception(f"Failed to instantiate '{provider_name}': {e}")
+                        raise ProviderConfigError(f"Provider initialization failed: {e}")
+
+        provider: TranslationProvider = entry["instance"]
+
+        if not provider.is_available():
+            raise RuntimeError(f"Provider '{provider_name}' is currently unavailable.")
+
+        # Pass the extra kwargs down to support provider-specific settings
+        return provider.translate(text, source_lang, target_lang, **kwargs)

--- a/flask/tests/test_provider_architecture.py
+++ b/flask/tests/test_provider_architecture.py
@@ -1,0 +1,223 @@
+"""
+tests covering the translation provider architecture, 
+ensuring the abstract interface and double-checked locking behave as expected
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+import pytest
+
+from providers.base import TranslationProvider, TranslationError, ProviderConfigError
+from providers.registry import (
+    ProviderRegistry,
+    register_provider,
+    available_providers,
+)
+
+#concrete providers used in tests
+class EchoProvider(TranslationProvider):
+    """Returns the input text unchanged. Tracks instantiation count."""
+
+    instantiation_count = 0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Enforces threads to collide in the concurrency test
+        # to guarantee the double-checked lock is actually tested
+        time.sleep(0.05) 
+        EchoProvider.instantiation_count += 1
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return text
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "echo"
+
+class FailingProvider(TranslationProvider):
+    """Raises TranslationError on every translate() call."""
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        raise TranslationError("intentional failure")
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "failing"
+
+class ConfigCapturingProvider(TranslationProvider):
+    """Stores the config it receives so tests can assert on it."""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.received_config = dict(self.config)
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "config_capturing"
+    
+class KwargsCapturingProvider(TranslationProvider):
+    """Stores the kwargs passed to translate() so tests can assert on them"""
+    def __init__(self, config=None):
+        super().__init__(config)
+        self.last_kwargs = {}
+
+    def translate(self, text, source_lang, target_lang, **kwargs):
+        self.last_kwargs = kwargs
+        return f"translated:{text}"
+
+    def is_available(self):
+        return True
+
+    @property
+    def provider_name(self):
+        return "kwargs_capturing"
+
+
+#Fixtures
+
+@pytest.fixture(autouse=True)
+def clean_factories():
+    with patch("providers.registry._PROVIDER_FACTORIES", {}) as mock_dict:
+        yield mock_dict
+
+@pytest.fixture
+def registry() -> ProviderRegistry:
+    return ProviderRegistry()
+
+
+#Abstract interface test
+class TestAbstractInterface:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            TranslationProvider()
+
+    def test_must_implement_translate(self) -> None:
+        class Incomplete(TranslationProvider):
+            def is_available(self): return True
+            @property
+            def provider_name(self): return "incomplete"
+
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_config_stored_as_copy(self) -> None:
+        config = {"api_key": "secret"}
+        provider = EchoProvider(config=config)
+        config["api_key"] = "mutated"
+        assert provider.config["api_key"] == "secret"
+
+
+#Registration & Configuration tests
+class TestProviderRegistration:
+    def test_register_and_list(self) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        assert "echo" in available_providers()
+
+class TestRegistryConfigure:
+    def test_configure_passes_config_to_provider(self, registry: ProviderRegistry) -> None:
+        register_provider("config_capturing", lambda config: ConfigCapturingProvider(config))
+        registry.configure("config_capturing", api_key="secret-key")
+        
+        registry.translate("config_capturing", "hello", "en", "de")
+        instance = registry._providers["config_capturing"]["instance"]
+        assert instance.received_config["api_key"] == "secret-key"
+
+
+#Lazy instantiation tests
+class TestLazyInstantiation:
+    def test_provider_created_on_first_translate(self, registry: ProviderRegistry) -> None:
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
+        
+        # Instance should be None before translation
+        assert registry._providers["echo"]["instance"] is None
+        
+        registry.translate("echo", "hello", "en", "de")
+        
+        # Instance should exist after translation
+        assert registry._providers["echo"]["instance"] is not None
+
+
+#Translation tests
+class TestTranslate:
+    def test_translate_forwards_kwargs(self, registry: ProviderRegistry) -> None:
+        """Ensures kwargs like 'temperature' and 'formality' are passed to the provider"""
+        register_provider("kwargs_capturing", lambda config: KwargsCapturingProvider(config))
+        registry.configure("kwargs_capturing")
+        
+        registry.translate(
+            "kwargs_capturing", 
+            "hello", 
+            "en", 
+            "de", 
+            temperature=0.3, 
+            formality="informal"
+        )
+        
+        instance = registry._providers["kwargs_capturing"]["instance"]
+        assert instance.last_kwargs == {"temperature": 0.3, "formality": "informal"}
+
+    def test_translation_error_propagates(self, registry: ProviderRegistry) -> None:
+        """Ensure runtime TranslationErrors from the provider are properly propagated."""
+        register_provider("failing", lambda config: FailingProvider(config))
+        registry.configure("failing")
+        
+        with pytest.raises(TranslationError, match="intentional failure"):
+            registry.translate("failing", "hello", "en", "de")
+
+    def test_factory_error_raises_provider_config_error(self, registry: ProviderRegistry) -> None:
+        """Ensure errors during lazy initialization are caught and wrapped correctly."""
+        def bad_factory(config):
+            raise RuntimeError("missing heavy ML weights")
+
+        register_provider("broken", bad_factory)
+        registry.configure("broken")
+        
+        with pytest.raises(ProviderConfigError, match="Provider initialization failed"):
+            registry.translate("broken", "hello", "en", "de")
+
+
+# Thread safety test 
+class TestThreadSafety:
+    def test_concurrent_translate_same_provider(self, registry: ProviderRegistry) -> None:
+        """Multiple threads translating simultaneously must not bypass the lock."""
+        EchoProvider.instantiation_count = 0
+        register_provider("echo", lambda config: EchoProvider(config))
+        registry.configure("echo")
+
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                # All 20 threads will smash into the lock simultaneously here.
+                result = registry.translate("echo", "hello", "en", "de")
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert len(results) == 20
+        assert all(r == "hello" for r in results)
+        
+        #Even with 20 threads colliding, the model was only loaded into RAM exactly once
+        assert EchoProvider.instantiation_count == 1

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -20,6 +20,9 @@ from dotenv import load_dotenv
 # (and test runs) that delegate to a remote whisper.cpp server, where those
 # heavy deps are not installed.
 
+
+from providers.registry import ProviderRegistry
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -119,6 +122,8 @@ else:
 # ---------------------------------------------------------------------------
 # Shared in-memory state
 # ---------------------------------------------------------------------------
+
+registry = ProviderRegistry()
 
 # transcripts:  tenant_id -> { chunk_id -> {'transcript': str} }
 transcriptd = {}
@@ -503,6 +508,17 @@ def merge_and_split_transcripts(transcripts):
 # Swagger / flask-restx models
 # ---------------------------------------------------------------------------
 
+configure_input_model = api.model('ConfigureRequest', {
+    'tenant_id': fields.String(required=True, description='Tenant ID for the session'),
+    'provider_name': fields.String(required=True, description='Canonical name of the provider (deepl, whisper, openai)'),
+    'config': fields.Raw(required=False, description='Dictionary of provider-specific settings (api_key, model_size)')
+})
+
+configure_response_model = api.model('ConfigureResponse', {
+    'status': fields.String(description='Success or error status'),
+    'message': fields.String(description='Status details')
+})
+
 # NOTE: api.model() registrations must use unique names. The original code
 # used 'Transcript' for both the /transcribe ack and the transcript-payload
 # schema, which made flask-restx silently overwrite the first registration
@@ -545,6 +561,32 @@ session_response_model = api.model('SessionResponse', {
     'source': fields.String(description='Source name this session is registered under'),
 })
 
+
+
+@app.route('/api/v1/translate/configure', methods=['POST'])
+def configure_provider():
+   
+   
+    data = request.get_json(silent=True) or {}
+    
+    provider_name = data.get("provider_name")
+    if not provider_name:
+        return jsonify({"status": "error", "message": "Missing 'provider_name'"}), 400
+        
+    # Extract extra config variables to pass as **kwargs
+    config_kwargs = {k: v for k, v in data.items() if k != "provider_name"}
+    
+    try:
+        registry.configure(provider_name=provider_name, **config_kwargs)
+        return jsonify({
+            "status": "success",
+            "message": f"Provider '{provider_name}' registered successfully."
+        }), 200
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+    except Exception as e:
+        return jsonify({"status": "error", "message": f"Configuration failed: {str(e)}"}), 500
+    
 
 @api.route('/session')
 class Session(Resource):


### PR DESCRIPTION
***background***:

When multiple organizers run events on our server at the same time, we need strict boundaries. We cannot let Organizer A's settings overwrites by Organizer B's settings.

**fixes**:
#60 , #62 

This PR introduces the core Provider Manager (registry.py) and the Abstract Base Class (base.py) to standardize how AI models are registered and plugged into our server, incorporating lazy loading to conserve memory until models are actively requested.

NOTE: **in this PR multi tenant isolation is not considered, in next PR it will be handeled**
 
- Implemented lazy loading in registry.py which saves server memory by waiting to boot up heavy models until the exact moment the speaker actually starts talking.
- as we designed base.py it creates a universal blueprint so future developers can easily drop in new AI models without rewriting the core server code.
- also added a basic /api/v1/translate/configure enpoint in transcribe_server.py , which can be use to test a registry.. this endpoint is in a very basic stage right now it will be upgraded in follow up prs.

***How To Test***:
- **start the server**
```bash
uv run python flask/transcribe_server.py
```
- **add this code snippet in bottom of registry.py to register mock providers**:
```bash
class _DevMockProvider(TranslationProvider):
    def __init__(self, config: Dict[str, Any]):
        self.config = config
        self._name = "mock"

    def is_available(self) -> bool:
        return True

    def translate(self, text: str, source_lang: str, target_lang: str, **kwargs: Any) -> str:
        return f"[Dev Mock Translation] {text}"

# basic placeholders for manual curl testing
register_provider("mock", lambda cfg: _DevMockProvider(cfg))
register_provider("nllb", lambda cfg: _DevMockProvider(cfg))
register_provider("openai", lambda cfg: _DevMockProvider(cfg))
```
- **curl for the mock provider**:
```bash
curl -X POST http://127.0.0.1:5040/api/v1/translate/configure \
-H "Content-Type: application/json" \
-d '{
  "provider_name": "mock",
  "api_key": "test-key-123",
  "custom_setting": "enabled"
}'
```

***Results:***
- **expected output of server logs as we implemented lazy loading of models(must not load the models on server start)**:
<img width="1785" height="306" alt="image" src="https://github.com/user-attachments/assets/14d51b47-c717-4c01-96cf-305a2effba0b" />

- **expected result on mock curl (to check registry)** :
<img width="1321" height="127" alt="image" src="https://github.com/user-attachments/assets/839418ec-23a7-4dc1-81e9-882192cf2434" />

- test run :
<img width="1887" height="287" alt="image" src="https://github.com/user-attachments/assets/61a6b7d6-2391-41b8-9f00-578d9f1957fe" />
