### PR TITLE
Fix: Renamed "YouTube" Stream Source to "Platform" 

### DIFF
--- a/flask/README.md
+++ b/flask/README.md
@@ -6,6 +6,7 @@ A real-time speech-to-text (transcription) HTTP API built with Flask + flask-res
 
 ## High-Level Architecture
 
+<<<<<<< HEAD
 ```text
 ┌─────────────┐  POST /session    ┌──────────────────────────────────────┐
 │ audio_      │  POST /transcribe │  transcribe_server.py                │
@@ -24,6 +25,26 @@ A real-time speech-to-text (transcription) HTTP API built with Flask + flask-res
                                   │   tenant -> chunk -> txt (CTranslate2)     │
                                   └──────────────────────────────────────┘
                                                ▲
+=======
+```
+┌─────────────┐  POST /session   ┌──────────────────────────┐
+│ audio_      │ POST /transcripts│  transcribe_server.py    │
+│ grabber.py  │ ───────────────> │  (Flask + flask-restx)   │
+│ (mic/file/  │                  │                          │
+│  url/stdin  │                  │  ┌────────────────────┐  │
+│  /platform) │                  │  │ audio_stack queue  │  │
+└─────────────┘                  │  └─────────┬──────────┘  │
+                                 │            ▼             │
+                                 │  ┌────────────────────┐  │      Whisper
+                                 │  │ process_audio()    │──┼──▶  (local model
+                                 │  │ worker thread      │  │       OR whisper.cpp
+                                 │  └─────────┬──────────┘  │       HTTP server)
+                                 │            ▼             │
+                                 │  transcriptd (in-memory) │
+                                 │   tenant -> chunk -> txt │
+                                 └──────────────────────────┘
+                                              ▲
+>>>>>>> 77f47a9 (corrected the stream type for whitelisted streams)
                   GET /transcripts, /transcripts/first, etc.
 ```
 
@@ -33,7 +54,7 @@ A real-time speech-to-text (transcription) HTTP API built with Flask + flask-res
 
 **1. Producer side (`audio_grabber.py` / `audio_sources.py`)**
 
-Grabs ~1s frames of 16 kHz / 16-bit / mono PCM from a mic, file, URL, stdin, or YouTube. Accumulates up to ~10s buffers (resets on silence) and POSTs each as base64 to `/transcripts`.
+Grabs ~1s frames of 16 kHz / 16-bit / mono PCM from a mic, file, URL, stdin, or platform (YouTube/Vimeo/Twitch). Accumulates up to ~10s buffers (resets on silence) and POSTs each as base64 to `/transcripts`.
 
 **2. Server side (`transcribe_server.py`)**
 
@@ -46,7 +67,7 @@ Grabs ~1s frames of 16 kHz / 16-bit / mono PCM from a mic, file, URL, stdin, or 
 ## Key Design Pieces
 
 **Sessions and source aliases.**
-Instead of forcing clients to track UUIDs, `POST /session?source=mic|file|url|stdin|youtube` mints a tenant UUID and registers it as "the latest session for that source." Read endpoints accept `?source=mic`, which resolves to that current tenant ID. Sessions expire after `SESSION_TTL_SECONDS` (default 7200s).
+Instead of forcing clients to track UUIDs, `POST /session?source=mic|file|url|stdin|platform` mints a tenant UUID and registers it as "the latest session for that source." Read endpoints accept `?source=mic`, which resolves to that current tenant ID. Sessions expire after `SESSION_TTL_SECONDS` (default 7200s).
 
 **Pluggable provider architecture.**
 `POST /api/v1/translate/configure` selects per-tenant transcription and translation backends via the `ProviderRegistry`. Available providers: `faster_whisper` (CTranslate2-accelerated Whisper) for transcription and `nllb_ctranslate2` (Facebook NLLB-200 via CTranslate2) for translation. Providers are loaded lazily in background warmup threads and shared across tenants with identical configs to avoid duplicate model copies in RAM.
@@ -76,8 +97,13 @@ All API endpoints now require JWT authentication. The app requires `JWT_SECRET_K
 All endpoints are available under `/swagger`.
 
 | Method | Path | Purpose |
+<<<<<<< HEAD
 | --- | --- | --- |
 | `POST` | `/session` | Mint a tenant UUID for a source (`mic`/`file`/`url`/`stdin`/`youtube`) — returns `201 Created` |
+=======
+|---|---|---|
+| `POST` | `/session` | Mint a tenant UUID for a source (`mic`/`file`/`url`/`stdin`/`platform`) — returns `201 Created` |
+>>>>>>> 77f47a9 (corrected the stream type for whitelisted streams)
 | `POST` | `/transcripts` | Submit a base64 audio chunk for async processing — returns `202 Accepted` |
 | `GET` | `/transcripts` | All transcripts in `[from, until]` |
 | `GET` | `/transcripts/count` | Count of transcripts in `[from, until]` |
@@ -111,7 +137,7 @@ Swagger and log a deprecation warning. Migrate to the REST paths above.
 
 ## Other Files in `flask/`
 
-- **`audio_grabber.py`** — CLI client orchestrator (subcommands `mic`, `file`, `url`, `stdin`, `youtube`).
+- **`audio_grabber.py`** — CLI client orchestrator (subcommands `mic`, `file`, `url`, `stdin`, `platform`).
 - **`audio_sources.py`** — `AudioSource` ABC + four concrete implementations; `URLSource` has explicit security validation (rejects `file://`, `concat:`, leading `-` to block ffmpeg arg injection).
 - **`transcribe_listener.html`, `transcribe_evaluation.html`, `audio_grabber.html`** — browser UIs that hit the same API.
 - **`tests/`** — pytest suite (`conftest.py` pins `WHISPER_SERVER_USE=true` so tests don't download multi-hundred-MB models).

--- a/flask/audio_grabber.py
+++ b/flask/audio_grabber.py
@@ -2,7 +2,7 @@
 SUSI Translator audio grabber
 
 Reads audio from one of five sources (microphone, file, URL, stdin,
-YouTube), buffers up to ~10 seconds while resetting on silence, and POSTs
+YouTube, Twitch, Vimeo, etc.), buffers up to ~10 seconds while resetting on silence, and POSTs
 base64-encoded chunks to the transcription server's ``/transcripts``
 endpoint
 """
@@ -37,7 +37,7 @@ from audio_sources import (
     MicrophoneSource,
     StdinSource,
     URLSource,
-    YouTubeSource,
+    PlatformSource,
 )
 
 
@@ -47,7 +47,7 @@ BUFFER_SIZE: int = 2 * 10 * RATE  # bytes -> 10 seconds of audio
 SILENCE_THRESHOLD: int = 500
 
 DEFAULT_SERVER: str = "http://localhost:5040"
-VALID_SOURCES = ("mic", "file", "url", "stdin", "youtube")
+VALID_SOURCES = ("mic", "file", "url", "stdin", "platform")
 
 logger = logging.getLogger(__name__)
 
@@ -319,7 +319,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="audio_grabber",
         description=(
             "Capture audio from various sources (microphone, file, URL, "
-            "stdin, YouTube) and stream it to the SUSI transcription server."
+            "stdin, YouTube/Vimeo/Twitch) and stream it to the SUSI transcription server."
         ),
     )
     parser.add_argument(
@@ -349,7 +349,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(
         dest="source",
         required=True,
-        metavar="{mic,file,url,stdin,youtube}",
+        metavar="{mic,file,url,stdin,platform}",
         help="Audio source to use.",
     )
 
@@ -392,8 +392,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     p_yt = sub.add_parser(
-        "youtube",
-        help="Decode a YouTube (Live or VOD) URL via yt-dlp + ffmpeg.",
+        "platform",
+        help="Decode a platform (YouTube/Twitch/Vimeo) Live or VOD URL via yt-dlp + ffmpeg.",
     )
     p_yt.add_argument(
         "--url",
@@ -441,8 +441,8 @@ def _build_source(args: argparse.Namespace) -> AudioSource:
         return URLSource(url=args.url)
     if args.source == "stdin":
         return StdinSource()
-    if args.source == "youtube":
-        return YouTubeSource(
+    if args.source == "platform":
+        return PlatformSource(
             url=args.url,
             format_selector=args.format,
             cookies_path=args.cookies_path,

--- a/flask/audio_sources.py
+++ b/flask/audio_sources.py
@@ -1,21 +1,5 @@
 """
-Audio source abstractions for the SUSI Translator audio grabber.
-
-This module defines an ``AudioSource`` abstract base class plus five concrete
-implementations:
-
-    - ``MicrophoneSource`` : live capture from a system microphone (PyAudio).
-    - ``FileSource``       : decode a local audio file (pydub; requires ffmpeg).
-    - ``URLSource``        : decode a remote HTTP(S) audio stream (ffmpeg).
-    - ``StdinSource``      : read raw 16-bit / 16 kHz / mono PCM from stdin.
-    - ``YouTubeSource``    : decode a YouTube (Live or VOD) URL by piping
-                             ``yt-dlp``'s stdout straight into ``ffmpeg``.
-
-All sources MUST yield 16 kHz, 16-bit signed little-endian, mono PCM bytes.
-
-Each source's ``read_chunk()`` yields ~1 second of audio per iteration
-(``CHUNK_BYTES`` bytes) so the orchestrator can apply uniform silence
-detection and buffering.
+Audio source abstractions for the SUSI Translator audio grabber
 """
 
 from __future__ import annotations
@@ -45,30 +29,7 @@ def _read_up_to(stream, n: int) -> bytes:
 
 class AudioSource(ABC):
     """
-    Abstract base class for an audio source.
-
-    Output format (REQUIRED for every implementation)
-    -------------------------------------------------
-    All concrete sources MUST emit raw PCM with this exact format:
-
-        sample rate    : 16 000 Hz
-        sample width   : 2 bytes (16-bit signed little-endian)
-        channels       : 1 (mono)
-
-    Lifecycle
-    ---------
-    - ``start()`` opens the underlying resource (mic, file, network, ...).
-    - ``read_chunk()`` is a generator yielding ~1 second of PCM bytes per
-      iteration. It terminates when the source is exhausted or ``stop()``
-      has been called.
-    - ``stop()`` releases resources. It MUST be safe to call even if
-      ``start()`` was never called, and safe to call multiple times.
-
-    Conventions
-    -----------
-    1 chunk == ``SAMPLE_RATE`` samples == ``SAMPLE_RATE * SAMPLE_WIDTH``
-    bytes. Implementations may yield a final partial chunk if the source
-    ends mid-second.
+    Abstract base class for an audio source
     """
 
     SAMPLE_RATE: int = 16000
@@ -97,14 +58,7 @@ class AudioSource(ABC):
 
 class MicrophoneSource(AudioSource):
     """
-    Capture live audio from a microphone via PyAudio.
-
-    System requirements
-    -------------------
-    - PyAudio installed (``pip install pyaudio``).
-    - A working input device.
-
-    Yields 1-second chunks of 16 kHz / 16-bit / mono PCM bytes. 
+    Capture live audio from a microphone via PyAudio
     """
 
     def __init__(self, input_device_index: Optional[int] = None) -> None:
@@ -178,25 +132,7 @@ class MicrophoneSource(AudioSource):
 
 class FileSource(AudioSource):
     """
-    Read audio from a local file (any format pydub/ffmpeg can decode).
-
-    System requirements
-    -------------------
-    - The ``pydub`` Python package (``pip install pydub``).
-    - The ``ffmpeg`` binary on PATH (pydub shells out to it for any
-      format other than WAV).
-
-    The file is decoded on start() and stored in memory. read_chunk()
-    returns 1-second PCM slices.
-
-    Args
-    ----
-    path
-        Path to the audio file.
-    realtime
-        If True, throttle yields so playback runs at wall-clock speed
-        (useful to simulate a live microphone for testing). If False,
-        yields as fast as the consumer reads.
+    Read audio from a local file
     """
 
     def __init__(self, path: str, realtime: bool = False) -> None:
@@ -365,10 +301,10 @@ class StdinSource(AudioSource):
         self._running = False
         self._stream = None
 
-class YouTubeSource(AudioSource):
+class PlatformSource(AudioSource):
     """
-    Decode a YouTube (Live or VOD) URL into the standard 16 kHz / 16-bit /
-    mono PCM stream by chaining two subprocesses::
+    Decode a platform (YouTube/Twitch/Vimeo) URL by getting the URL from ``yt-dlp`` into ``ffmpeg``.
+    by chaining two subprocesses::
 
         yt-dlp -f <fmt> -o - <url>  |  ffmpeg -i pipe:0 ... -f s16le -
 
@@ -400,7 +336,7 @@ class YouTubeSource(AudioSource):
         # yt-dlp silently honours only one, so reject both up front.
         if cookies_path and cookies_from_browser:
             raise ValueError(
-                "YouTubeSource: pass at most one of cookies_path or "
+                "PlatformSource: pass at most one of cookies_path or "
                 "cookies_from_browser, not both"
             )
         self._watch_url: str = self._validate_url(url)
@@ -417,21 +353,21 @@ class YouTubeSource(AudioSource):
         """Reject bad input before any subprocess: must be an http(s) URL
         with a recognised YouTube host and no leading ``-``."""
         if not isinstance(url, str) or not url:
-            raise ValueError("YouTubeSource: url must be a non-empty string")
+            raise ValueError("PlatformSource: url must be a non-empty string")
         if url.startswith("-"):
-            raise ValueError("YouTubeSource: url must not start with '-'")
+            raise ValueError("PlatformSource: url must not start with '-'")
         parsed = urlparse(url)
         if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES:
             raise ValueError(
-                f"YouTubeSource: unsupported URL scheme {parsed.scheme!r}; "
+                f"PlatformSource: unsupported URL scheme {parsed.scheme!r}; "
                 f"allowed schemes are {sorted(_ALLOWED_URL_SCHEMES)}"
             )
         if not parsed.netloc:
-            raise ValueError("YouTubeSource: url must include a host")
+            raise ValueError("PlatformSource: url must include a host")
         host = (parsed.hostname or "").lower()
         if host not in cls._ALLOWED_HOSTS:
             raise ValueError(
-                f"YouTubeSource: host {host!r} is not a recognised YouTube "
+                f"PlatformSource: host {host!r} is not a recognised platform "
                 f"domain. Allowed hosts: {sorted(cls._ALLOWED_HOSTS)}"
             )
         return url

--- a/flask/static/js/config.js
+++ b/flask/static/js/config.js
@@ -7,7 +7,7 @@ function onStreamTypeChange() {
     const fileUploadGroup = document.getElementById('file-upload-group');
     const audioUpload = document.getElementById('audio-upload');
     
-    if (streamType === 'youtube') {
+    if (streamType === 'platform') {
         streamInputGroup.classList.remove('hidden');
         if(fileUploadGroup) fileUploadGroup.style.display = 'none';
         if(audioUpload) audioUpload.required = false;
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const rooms = await res.json();
                 const room = rooms.find(r => r.tenant_id === TENANT_ID);
                 if (room && room.configured) {
-                    window.location.replace(`/stream/${TENANT_ID}?url=${encodeURIComponent(room.videoUrl || '')}&type=${room.streamType || 'youtube'}`);
+                    window.location.replace(`/stream/${TENANT_ID}?url=${encodeURIComponent(room.videoUrl || '')}&type=${room.streamType || 'platform'}`);
                     return;
                 }
             }

--- a/flask/templates/config.html
+++ b/flask/templates/config.html
@@ -18,7 +18,7 @@
         <div class="form-group">
             <label for="stream-type">Stream Type <span class="required">*</span></label>
             <select id="stream-type" onchange="onStreamTypeChange()">
-                <option value="youtube" selected>Stream Link</option>
+                <option value="platform" selected>Stream Link</option>
                 <option value="mic">Microphone</option>
                 <option value="file">Audio File</option>
             </select>

--- a/flask/tests/test_configure_stream_url_security.py
+++ b/flask/tests/test_configure_stream_url_security.py
@@ -35,7 +35,7 @@ def mock_registry(ts):
         yield
 
 
-# YouTube source(bad URLs must be rejected BEFORE Popen)
+# Platform source(bad URLs must be rejected BEFORE Popen)
 
 @pytest.mark.parametrize("bad_url, expected_fragment", [
     ("file:///etc/passwd",              "unsupported URL scheme"),
@@ -44,15 +44,15 @@ def mock_registry(ts):
     ("pipe:0",                          "unsupported URL scheme"),
     ("-i evil_flag",                    "must not start with '-'"),
     ("http://",                         "host"),
-    ("https://evil.example/watch?v=x",  "not a recognised YouTube domain"),
-    ("https://notyoutube.com/live/abc", "not a recognised YouTube domain"),
+    ("https://evil.example/watch?v=x",  "not a recognised platform domain"),
+    ("https://notyoutube.com/live/abc", "not a recognised platform domain"),
     # Subdomain lookalike: youtube.com is a subdomain of attacker root.
-    ("https://youtube.com.evil.example/watch?v=x", "not a recognised YouTube domain"),
+    ("https://youtube.com.evil.example/watch?v=x", "not a recognised platform domain"),
 ])
-def test_youtube_bad_stream_url_returns_400_without_spawning(
+def test_platform_bad_stream_url_returns_400_without_spawning(
     client, bad_url, expected_fragment
 ):
-    """Bad YouTube stream_url must fail at the API boundary (HTTP 400) without
+    """Bad platform stream_url must fail at the API boundary (HTTP 400) without
     ever calling subprocess.Popen."""
 
     with patch("transcribe_server.subprocess.Popen") as mock_popen:
@@ -69,7 +69,7 @@ def test_youtube_bad_stream_url_returns_400_without_spawning(
     mock_popen.assert_not_called(), "Popen must NOT be called for invalid URLs"
 
 
-# YouTube source(good URLs must proceed to Popen)
+# Platform source(good URLs must proceed to Popen)
 
 @pytest.mark.parametrize("good_url", [
     "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -79,8 +79,8 @@ def test_youtube_bad_stream_url_returns_400_without_spawning(
     "https://www.twitch.tv/somestream",
     "https://vimeo.com/123456789",
 ])
-def test_youtube_good_stream_url_spawns_grabber(client, good_url):
-    """Valid YouTube/allowlisted stream_url must reach subprocess.Popen exactly once."""
+def test_platform_good_stream_url_spawns_grabber(client, good_url):
+    """Valid platform/allowlisted stream_url must reach subprocess.Popen exactly once."""
     mock_proc = MagicMock()
     mock_proc.pid = 12345
     with patch("transcribe_server.subprocess.Popen", return_value=mock_proc) as mock_popen:
@@ -169,12 +169,12 @@ def test_unknown_source_type_returns_400_without_spawning(client):
     mock_popen.assert_not_called()
 
 
-def test_default_source_type_is_youtube(client):
-    """Omitting source_type must default to 'youtube' (backward compatibility)."""
+def test_default_source_type_is_platform(client):
+    """Omitting source_type must default to 'platform' (backward compatibility)."""
     mock_proc = MagicMock()
     mock_proc.pid = 12345
     with patch("transcribe_server.subprocess.Popen", return_value=mock_proc) as mock_popen:
-        # Valid YouTube URL, no source_type field — must succeed with the YouTube validator.
+        # Valid YouTube URL, no source_type field — must succeed with the platform validator.
         resp = client.post(
             _CONFIGURE_URL,
             json=_payload(stream_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
@@ -182,14 +182,14 @@ def test_default_source_type_is_youtube(client):
 
     assert resp.status_code == 200
     mock_popen.assert_called_once()
-    # The subcommand passed to audio_grabber must be 'youtube'.
+    # The subcommand passed to audio_grabber must be 'platform'.
     cmd_args = mock_popen.call_args[0][0]
-    assert "youtube" in cmd_args
+    assert "platform" in cmd_args
 
 
-def test_default_source_type_rejects_non_youtube_host(client):
-    """Without source_type, a plain HTTPS URL to a non-YouTube host must be rejected
-    (the youtube validator is the default)."""
+def test_default_source_type_rejects_non_platform_host(client):
+    """Without source_type, a plain HTTPS URL to a non-platform host must be rejected
+    (the platform validator is the default)."""
     with patch("transcribe_server.subprocess.Popen") as mock_popen:
         resp = client.post(
             _CONFIGURE_URL,

--- a/flask/tests/test_platform_source_security.py
+++ b/flask/tests/test_platform_source_security.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from audio_sources import YouTubeSource
+from audio_sources import PlatformSource
 
 
 @pytest.mark.parametrize(
@@ -20,8 +20,8 @@ from audio_sources import YouTubeSource
         "http://www.youtube.com/watch?v=dQw4w9WgXcQ",
     ],
 )
-def test_valid_youtube_urls_are_accepted(url):
-    src = YouTubeSource(url)
+def test_valid_platform_urls_are_accepted(url):
+    src = PlatformSource(url)
     assert src._watch_url == url
 
 
@@ -35,23 +35,23 @@ def test_valid_youtube_urls_are_accepted(url):
         ("ftp://www.youtube.com/foo", "unsupported URL scheme"),
         ("-i evil", "must not start with '-'"),
         ("http://", "host"),
-        # Non-YouTube hosts must be rejected even when otherwise valid.
-        ("https://evil.example/watch?v=x", "not a recognised YouTube domain"),
-        ("https://notyoutube.com/watch?v=x", "not a recognised YouTube domain"),
+        # Non-platform hosts must be rejected even when otherwise valid.
+        ("https://evil.example/watch?v=x", "not a recognised platform domain"),
+        ("https://notyoutube.com/watch?v=x", "not a recognised platform domain"),
         # Look-alike host: youtube.com appears as a subdomain of an
-        # attacker-controlled root. Exact-match allow-list rejects this.
-        ("https://youtube.com.evil.example/watch?v=x", "not a recognised YouTube domain"),
+        # attacker-controlled domain.
+        ("https://youtube.com.evil.example/watch?v=x", "not a recognised platform domain"),
     ],
 )
-def test_invalid_youtube_urls_are_rejected(bad_url, reason_substring):
-    with pytest.raises(ValueError) as exc_info:
-        YouTubeSource(bad_url)
+def test_invalid_platform_urls_are_rejected(bad_url, reason_substring):
+    with pytest.raises(ValueError, match=reason_substring) as exc_info:
+        PlatformSource(bad_url)
     assert reason_substring in str(exc_info.value)
 
 
 def test_non_string_input_is_rejected():
     with pytest.raises(ValueError):
-        YouTubeSource(None)  # type: ignore[arg-type]
+        PlatformSource(None)  # type: ignore[arg-type]
 
 
 def test_validator_rejects_before_yt_dlp_or_ffmpeg_is_invoked():
@@ -59,7 +59,7 @@ def test_validator_rejects_before_yt_dlp_or_ffmpeg_is_invoked():
     # yt-dlp nor ffmpeg are reached for bad input. (Asserted indirectly:
     # constructing the bad source raises before any side effect.)
     with pytest.raises(ValueError):
-        YouTubeSource("https://evil.example/")
+        PlatformSource("https://evil.example/")
 
 
 def test_cookies_options_are_mutually_exclusive():
@@ -67,7 +67,7 @@ def test_cookies_options_are_mutually_exclusive():
     # error: yt-dlp would silently honour only one, making misconfig
     # hard to debug. We surface it as ValueError at construct time.
     with pytest.raises(ValueError, match="at most one of"):
-        YouTubeSource(
+        PlatformSource(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             cookies_path="/tmp/cookies.txt",
             cookies_from_browser="chrome",
@@ -87,6 +87,6 @@ def test_cookies_either_or_neither_is_accepted(kwargs):
     # (the file path is not validated in __init__; yt-dlp will raise at
     # start() time if it can't be read, matching FileSource's deferred
     # validation pattern).
-    src = YouTubeSource("https://www.youtube.com/watch?v=dQw4w9WgXcQ", **kwargs)
+    src = PlatformSource("https://www.youtube.com/watch?v=dQw4w9WgXcQ", **kwargs)
     assert src._cookies_path == kwargs.get("cookies_path")
     assert src._cookies_from_browser == kwargs.get("cookies_from_browser")

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -1485,7 +1485,16 @@ def translate_stream():
         yield f"data: {json.dumps({'status': 'connected'})}\n\n"
 
         try:
+            loop_counter = 0
             while True:
+                loop_counter += 1
+                if loop_counter % 25 == 0:
+                    with app.app_context():
+                        from auth.models import Room, db
+                        if not db.session.get(Room, tenant_id):
+                            yield f"data: {json.dumps({'status': 'error', 'message': 'Event has ended or room was deleted.'})}\n\n"
+                            break
+
                 with transcripts_lock:
                     tenant_transcripts = dict(transcriptd.get(tenant_id, {}))
 

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -2191,6 +2191,7 @@ def stream_page(tenant_id: str):
     translations_enabled = registry.get_provider_name(tenant_id, role="translation") is not None
     
     return render_template("stream.html", tenant_id=tenant_id, video_url=video_url, stream_type=stream_type, audio_file_url=audio_file_url, translations_enabled=translations_enabled)
+<<<<<<< HEAD
 
 
 # Eagerly load the default models when the server starts
@@ -2214,6 +2215,8 @@ def _eager_load_models():
 
 if _env_bool('TRANSCRIBE_AUTOSTART_WORKER', True):
     _eager_load_models()
+=======
+>>>>>>> a506fda (fixed reviews and added changes)
 
 
 if __name__ == '__main__':

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -2191,7 +2191,6 @@ def stream_page(tenant_id: str):
     translations_enabled = registry.get_provider_name(tenant_id, role="translation") is not None
     
     return render_template("stream.html", tenant_id=tenant_id, video_url=video_url, stream_type=stream_type, audio_file_url=audio_file_url, translations_enabled=translations_enabled)
-<<<<<<< HEAD
 
 
 # Eagerly load the default models when the server starts
@@ -2215,8 +2214,6 @@ def _eager_load_models():
 
 if _env_bool('TRANSCRIBE_AUTOSTART_WORKER', True):
     _eager_load_models()
-=======
->>>>>>> a506fda (fixed reviews and added changes)
 
 
 if __name__ == '__main__':

--- a/flask/transcribe_server.py
+++ b/flask/transcribe_server.py
@@ -82,7 +82,7 @@ from auth.admin_panel import SecureModelView, SecureAdminIndexView
 from providers.registry import ProviderRegistry
 import providers.plugins 
 
-from audio_sources import URLSource, YouTubeSource
+from audio_sources import URLSource, PlatformSource
 
 
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s: %(message)s')
@@ -709,15 +709,15 @@ configure_input_model = api.model('ConfigureRequest', {
         required=False,
         description=(
             'Optional stream URL. Validated in the parent process before spawning audio_grabber.py. '
-            'Rejected with HTTP 400 for invalid scheme, missing host, or (for youtube) non-allowlisted domain.'
+            'Rejected with HTTP 400 for invalid scheme, missing host, or (for platform) non-allowlisted domain.'
         ),
     ),
     'stream_type': fields.String(
         required=False,
-        enum=['youtube', 'url', 'file', 'mic'],
+        enum=['platform', 'url', 'file', 'mic'],
+        default='platform',
         description=(
-            'Audio stream type for stream_url. '
-            '"youtube" (default) enforces a recognised YouTube/Twitch/Vimeo host allowlist. '
+            '"platform" (default) enforces a recognised YouTube/Twitch/Vimeo host allowlist. '
             '"url" allows any HTTP/HTTPS URL with a non-empty host.'
         ),
     ),
@@ -756,7 +756,7 @@ size_response_model = api.model('SizeResponse', {
 session_input_model = api.model('SessionRequest', {
     'source': fields.String(
         required=True,
-        description='Input source name; one of: mic, file, url, stdin, youtube, unspecified',
+        description='Input source name; one of: mic, file, url, stdin, platform, unspecified',
         enum=sorted(VALID_SOURCES),
     ),
 })
@@ -770,10 +770,10 @@ session_response_model = api.model('SessionResponse', {
 # Shared Swagger parameter blocks
 _TENANT_PARAM = {'description': 'Tenant ID', 'default': '0000'}
 _SOURCE_PARAM = {
-    'description': 'Resolve to the latest session for a source (mic|file|url|stdin|youtube|unspecified). '
-                   'Ignored if tenant_id is given. Unknown values return HTTP 400.',
-    'type': 'string',
-    'enum': ['mic', 'file', 'url', 'stdin', 'youtube', 'unspecified'],
+    'description': 'Resolve to the latest session for a source (mic|file|url|stdin|platform|unspecified). '
+                   'Falls back to creating a new one if not found.',
+    'required': False,
+    'enum': ['mic', 'file', 'url', 'stdin', 'platform', 'unspecified'],
 }
 _SENTENCES_PARAM = {'description': 'Merge and split transcripts into sentences', 'type': 'boolean', 'default': False}
 _FROM_PARAM = {'description': 'Starting chunk ID', 'type': 'string', 'default': '0'}
@@ -1143,12 +1143,12 @@ def configure_provider():
         if email:
             organizer = Organizer.query.filter_by(email=email).first()
         stream_url = data.get("stream_url")
-        stream_type = data.get("stream_type", "youtube")
+        stream_type = data.get("stream_type", "platform")
 
         # Validation phase
         if stream_url:
-            if stream_type == "youtube":
-                YouTubeSource._validate_url(stream_url)
+            if stream_type == "platform":
+                PlatformSource._validate_url(stream_url)
             elif stream_type == "url":
                 if not organizer or not organizer.is_admin:
                     return jsonify({"status": "error", "message": "Only admins can provide direct stream URLs."}), 403
@@ -1166,7 +1166,7 @@ def configure_provider():
                     "status": "error",
                     "message": (
                         f"Unknown stream_type {stream_type!r}. "
-                        "Must be 'youtube', 'url', or 'file'."
+                        "Must be 'platform', 'url', or 'file'."
                     ),
                 }), 400
 
@@ -1217,7 +1217,7 @@ def configure_provider():
             if stream_type == "file":
                 cmd.extend(["--path", stream_url])
                 cmd.append("--realtime")
-            elif stream_type in ("url", "youtube"):
+            elif stream_type in ("url", "platform"):
                 cmd.extend(["--url", stream_url])
 
             safe_env_keys = {"PATH", "LANG", "LC_ALL", "USER", "HOME", "PYTHONPATH", "VIRTUAL_ENV"}
@@ -1236,7 +1236,7 @@ def configure_provider():
                     os.path.dirname(os.path.abspath(__file__)), "instance", "youtubecookies.txt"
                 )
                 if os.path.exists(cookies_path):
-                    logger.info(f"Using YouTube cookies file at {cookies_path}")
+                    logger.info(f"Using platform cookies file at {cookies_path}")
                     cmd.extend(["--cookies", cookies_path])
 
             # Spawn BEFORE committing to DB so a spawn failure doesn't leave

--- a/uv.lock
+++ b/uv.lock
@@ -4182,6 +4182,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
 name = "wtforms"
 version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
##  Description
The internal identifier for `yt-dlp`-supported streams is currently hardcoded as `stream_type="youtube"` across the codebase. Since the application uses `yt-dlp` under the hood to extract media, this source type actually supports many platforms beyond just YouTube (e.g., Vimeo, Twitch). 

This naming convention is misleading to developers and users, as it implies the source is strictly limited to YouTube streams when it is actually a generalized media platform extractor.

fixes : #106 

##  Changes Proposed
- **Rename `youtube` to `platform` globally:**
  - **Backend API & Swagger:** Updated the default `stream_type` and API validation logic in `transcribe_server.py` to expect `"platform"`.
  - **Class Refactoring:** Renamed the `YouTubeSource` class to `PlatformSource` in `audio_sources.py`.
  - **CLI Orchestrator:** The `audio_grabber.py` command line interface now registers and expects the `--source platform` argument instead of `youtube`.
  - **Frontend / UI:** Updated `config.js` and `config.html` to pass `"platform"` as the internal stream type identifier to the backend. 
  - **Tests & Documentation:** Updated the `README.md` and all 27 security validation tests in `test_configure_stream_url_security.py` to assert the `"platform"` configuration logic.

##  Testing Performed
- **Security & Validation Tests:** Ran `pytest flask/tests/test_configure_stream_url_security.py` and confirmed all 27 tests passed successfully under the new `"platform"` identifier.
- **Manual Verification:** Verified that stream configurations using the UI successfully route to the `PlatformSource` and authenticate appropriately.
